### PR TITLE
properly clear channels on rule reload

### DIFF
--- a/src/main/java/org/openhab/automation/jrule/internal/engine/JRuleEngine.java
+++ b/src/main/java/org/openhab/automation/jrule/internal/engine/JRuleEngine.java
@@ -118,6 +118,7 @@ public class JRuleEngine implements PropertyChangeListener {
     public synchronized void reset() {
         itemNames.clear();
         itemToExecutionContexts.clear();
+        channelToExecutionContexts.clear();
         itemToRules.clear();
         clearTimers();
     }


### PR DESCRIPTION
@seaside1 I realized, that in case of a rule reload, the `channelToExecutionContexts` are not properly cleared. 