### PR TITLE
Extend commands

### DIFF
--- a/src/main/java/org/openhab/automation/jrule/internal/handler/JRuleEventHandler.java
+++ b/src/main/java/org/openhab/automation/jrule/internal/handler/JRuleEventHandler.java
@@ -22,6 +22,7 @@ import org.eclipse.jdt.annotation.NonNull;
 import org.openhab.automation.jrule.items.JRulePercentType;
 import org.openhab.automation.jrule.rules.value.JRuleColorValue;
 import org.openhab.automation.jrule.rules.value.JRuleHsbValue;
+import org.openhab.automation.jrule.rules.value.JRuleIncreaseDecreaseValue;
 import org.openhab.automation.jrule.rules.value.JRuleOnOffValue;
 import org.openhab.automation.jrule.rules.value.JRuleOpenClosedValue;
 import org.openhab.automation.jrule.rules.value.JRulePlayPauseValue;
@@ -38,6 +39,7 @@ import org.openhab.core.items.events.ItemEventFactory;
 import org.openhab.core.library.types.DateTimeType;
 import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.HSBType;
+import org.openhab.core.library.types.IncreaseDecreaseType;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.library.types.OpenClosedType;
 import org.openhab.core.library.types.PercentType;
@@ -87,6 +89,10 @@ public class JRuleEventHandler {
     }
 
     public void sendCommand(String itemName, JRuleOnOffValue command) {
+        sendCommand(itemName, getCommand(command));
+    }
+
+    public void sendCommand(String itemName, JRuleIncreaseDecreaseValue command) {
         sendCommand(itemName, getCommand(command));
     }
 
@@ -309,19 +315,6 @@ public class JRuleEventHandler {
         }
     }
 
-    private State getStateFromValue(JRuleOpenClosedValue value) {
-        switch (value) {
-            case OPEN:
-                return OpenClosedType.OPEN;
-            case CLOSED:
-                return OpenClosedType.CLOSED;
-            case UNDEF:
-            default:
-                logger.error("Unhandled getCommand: {}", value);
-                return null;
-        }
-    }
-
     private State getStateFromValue(JRulePlayPauseValue value) {
         switch (value) {
             case PLAY:
@@ -354,6 +347,19 @@ public class JRuleEventHandler {
                 return OnOffType.OFF;
             case ON:
                 return OnOffType.ON;
+            case UNDEF:
+            default:
+                logger.error("Unhandled getCommand: {}", command);
+                return null;
+        }
+    }
+
+    private Command getCommand(JRuleIncreaseDecreaseValue command) {
+        switch (command) {
+            case INCREASE:
+                return IncreaseDecreaseType.INCREASE;
+            case DECREASE:
+                return IncreaseDecreaseType.DECREASE;
             case UNDEF:
             default:
                 logger.error("Unhandled getCommand: {}", command);

--- a/src/main/java/org/openhab/automation/jrule/internal/handler/JRuleEventHandler.java
+++ b/src/main/java/org/openhab/automation/jrule/internal/handler/JRuleEventHandler.java
@@ -27,6 +27,8 @@ import org.openhab.automation.jrule.rules.value.JRuleOnOffValue;
 import org.openhab.automation.jrule.rules.value.JRuleOpenClosedValue;
 import org.openhab.automation.jrule.rules.value.JRulePlayPauseValue;
 import org.openhab.automation.jrule.rules.value.JRuleRgbValue;
+import org.openhab.automation.jrule.rules.value.JRuleStopMoveValue;
+import org.openhab.automation.jrule.rules.value.JRuleUpDownValue;
 import org.openhab.automation.jrule.rules.value.JRuleXyValue;
 import org.openhab.core.events.EventPublisher;
 import org.openhab.core.items.GroupItem;
@@ -44,7 +46,9 @@ import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.library.types.OpenClosedType;
 import org.openhab.core.library.types.PercentType;
 import org.openhab.core.library.types.PlayPauseType;
+import org.openhab.core.library.types.StopMoveType;
 import org.openhab.core.library.types.StringType;
+import org.openhab.core.library.types.UpDownType;
 import org.openhab.core.types.Command;
 import org.openhab.core.types.State;
 import org.slf4j.Logger;
@@ -93,6 +97,14 @@ public class JRuleEventHandler {
     }
 
     public void sendCommand(String itemName, JRuleIncreaseDecreaseValue command) {
+        sendCommand(itemName, getCommand(command));
+    }
+
+    public void sendCommand(String itemName, JRuleUpDownValue command) {
+        sendCommand(itemName, getCommand(command));
+    }
+
+    public void sendCommand(String itemName, JRuleStopMoveValue command) {
         sendCommand(itemName, getCommand(command));
     }
 
@@ -192,6 +204,10 @@ public class JRuleEventHandler {
     }
 
     public void postUpdate(String itemName, JRuleOnOffValue state) {
+        postUpdate(itemName, getStateFromValue(state));
+    }
+
+    public void postUpdate(String itemName, JRuleUpDownValue state) {
         postUpdate(itemName, getStateFromValue(state));
     }
 
@@ -315,6 +331,19 @@ public class JRuleEventHandler {
         }
     }
 
+    private State getStateFromValue(JRuleUpDownValue value) {
+        switch (value) {
+            case UP:
+                return UpDownType.UP;
+            case DOWN:
+                return UpDownType.DOWN;
+            case UNDEF:
+            default:
+                logger.error("Unhandled getCommand: {}", value);
+                return null;
+        }
+    }
+
     private State getStateFromValue(JRulePlayPauseValue value) {
         switch (value) {
             case PLAY:
@@ -347,6 +376,32 @@ public class JRuleEventHandler {
                 return OnOffType.OFF;
             case ON:
                 return OnOffType.ON;
+            case UNDEF:
+            default:
+                logger.error("Unhandled getCommand: {}", command);
+                return null;
+        }
+    }
+
+    private Command getCommand(JRuleUpDownValue command) {
+        switch (command) {
+            case UP:
+                return UpDownType.UP;
+            case DOWN:
+                return UpDownType.DOWN;
+            case UNDEF:
+            default:
+                logger.error("Unhandled getCommand: {}", command);
+                return null;
+        }
+    }
+
+    private Command getCommand(JRuleStopMoveValue command) {
+        switch (command) {
+            case STOP:
+                return StopMoveType.STOP;
+            case MOVE:
+                return StopMoveType.MOVE;
             case UNDEF:
             default:
                 logger.error("Unhandled getCommand: {}", command);

--- a/src/main/java/org/openhab/automation/jrule/items/JRuleColorItem.java
+++ b/src/main/java/org/openhab/automation/jrule/items/JRuleColorItem.java
@@ -14,6 +14,7 @@ package org.openhab.automation.jrule.items;
 
 import org.openhab.automation.jrule.internal.handler.JRuleEventHandler;
 import org.openhab.automation.jrule.rules.value.JRuleColorValue;
+import org.openhab.automation.jrule.rules.value.JRuleOnOffValue;
 
 /**
  * The {@link JRuleColorItem} Items
@@ -26,11 +27,35 @@ public abstract class JRuleColorItem extends JRuleItem {
         return JRuleEventHandler.get().getColorValue(itemName);
     }
 
+    public static JRuleOnOffValue getOnOffState(String itemName) {
+        return JRuleEventHandler.get().getOnOffValue(itemName);
+    }
+
+    public static int getPercentState(String itemName) {
+        return JRuleEventHandler.get().getStateFromItemAsInt(itemName);
+    }
+
     public static void sendCommand(String itemName, JRuleColorValue colorValue) {
         JRuleEventHandler.get().sendCommand(itemName, colorValue);
     }
 
+    public static void sendCommand(String itemName, JRuleOnOffValue command) {
+        JRuleEventHandler.get().sendCommand(itemName, command);
+    }
+
+    public static void sendCommand(String itemName, int value) {
+        JRuleEventHandler.get().sendCommand(itemName, new JRulePercentType(value));
+    }
+
     public static void postUpdate(String itemName, JRuleColorValue colorValue) {
         JRuleEventHandler.get().postUpdate(itemName, colorValue);
+    }
+
+    public static void postUpdate(String itemName, JRuleOnOffValue state) {
+        JRuleEventHandler.get().postUpdate(itemName, state);
+    }
+
+    public static void postUpdate(String itemName, int value) {
+        JRuleEventHandler.get().postUpdate(itemName, new JRulePercentType(value));
     }
 }

--- a/src/main/java/org/openhab/automation/jrule/items/JRuleColorItem.java
+++ b/src/main/java/org/openhab/automation/jrule/items/JRuleColorItem.java
@@ -14,6 +14,7 @@ package org.openhab.automation.jrule.items;
 
 import org.openhab.automation.jrule.internal.handler.JRuleEventHandler;
 import org.openhab.automation.jrule.rules.value.JRuleColorValue;
+import org.openhab.automation.jrule.rules.value.JRuleIncreaseDecreaseValue;
 import org.openhab.automation.jrule.rules.value.JRuleOnOffValue;
 
 /**
@@ -40,6 +41,10 @@ public abstract class JRuleColorItem extends JRuleItem {
     }
 
     public static void sendCommand(String itemName, JRuleOnOffValue command) {
+        JRuleEventHandler.get().sendCommand(itemName, command);
+    }
+
+    public static void sendCommand(String itemName, JRuleIncreaseDecreaseValue command) {
         JRuleEventHandler.get().sendCommand(itemName, command);
     }
 

--- a/src/main/java/org/openhab/automation/jrule/items/JRuleContactItem.java
+++ b/src/main/java/org/openhab/automation/jrule/items/JRuleContactItem.java
@@ -16,11 +16,11 @@ import org.openhab.automation.jrule.internal.handler.JRuleEventHandler;
 import org.openhab.automation.jrule.rules.value.JRuleOpenClosedValue;
 
 /**
- * The {@link JRuleOpenClosedItem} Items
+ * The {@link JRuleContactItem} Items
  *
  * @author Timo Litzius - Initial contribution
  */
-public abstract class JRuleOpenClosedItem extends JRuleItem {
+public abstract class JRuleContactItem extends JRuleItem {
 
     public static JRuleOpenClosedValue getState(String itemName) {
         return JRuleEventHandler.get().getOpenClosedValue(itemName);

--- a/src/main/java/org/openhab/automation/jrule/items/JRuleDimmerItem.java
+++ b/src/main/java/org/openhab/automation/jrule/items/JRuleDimmerItem.java
@@ -13,6 +13,7 @@
 package org.openhab.automation.jrule.items;
 
 import org.openhab.automation.jrule.internal.handler.JRuleEventHandler;
+import org.openhab.automation.jrule.rules.value.JRuleIncreaseDecreaseValue;
 import org.openhab.automation.jrule.rules.value.JRuleOnOffValue;
 
 /**
@@ -38,6 +39,10 @@ public abstract class JRuleDimmerItem extends JRuleItem {
     }
 
     public static void sendCommand(String itemName, JRuleOnOffValue command) {
+        JRuleEventHandler.get().sendCommand(itemName, command);
+    }
+
+    public static void sendCommand(String itemName, JRuleIncreaseDecreaseValue command) {
         JRuleEventHandler.get().sendCommand(itemName, command);
     }
 

--- a/src/main/java/org/openhab/automation/jrule/items/JRuleItemClassGenerator.java
+++ b/src/main/java/org/openhab/automation/jrule/items/JRuleItemClassGenerator.java
@@ -45,7 +45,7 @@ public class JRuleItemClassGenerator {
     private final URL stringItemClassTemplateUrl;
     private final URL dateTimeItemClassTemplateUrl;
     private final URL colorItemClassTemplateUrl;
-    private final URL openClosedItemClassTemplateUrl;
+    private final URL contactItemClassTemplateUrl;
     private final URL groupItemClassTemplateUrl;
 
     private final String itemClassTemplate;
@@ -55,7 +55,7 @@ public class JRuleItemClassGenerator {
     private final String numberItemClassTemplate;
     private final String stringItemClassTemplate;
     private final String colorItemClassTemplate;
-    private final String openClosedItemClassTemplate;
+    private final String contactItemClassTemplate;
     private final String dateTimeItemClassTemplate;
     private final String groupItemClassTemplate;
 
@@ -76,8 +76,8 @@ public class JRuleItemClassGenerator {
         stringItemClassTemplate = JRuleUtil.getResourceAsString(stringItemClassTemplateUrl);
         colorItemClassTemplateUrl = JRuleUtil.getResourceUrl("ItemClassColor.template");
         colorItemClassTemplate = JRuleUtil.getResourceAsString(colorItemClassTemplateUrl);
-        openClosedItemClassTemplateUrl = JRuleUtil.getResourceUrl("ItemClassOpenClosed.template");
-        openClosedItemClassTemplate = JRuleUtil.getResourceAsString(openClosedItemClassTemplateUrl);
+        contactItemClassTemplateUrl = JRuleUtil.getResourceUrl("ItemClassContact.template");
+        contactItemClassTemplate = JRuleUtil.getResourceAsString(contactItemClassTemplateUrl);
         dateTimeItemClassTemplateUrl = JRuleUtil.getResourceUrl("ItemClassDateTime.template");
         dateTimeItemClassTemplate = JRuleUtil.getResourceAsString(dateTimeItemClassTemplateUrl);
         groupItemClassTemplateUrl = JRuleUtil.getResourceUrl("ItemClassGroup.template");
@@ -118,7 +118,7 @@ public class JRuleItemClassGenerator {
         } else if (type.equals(CoreItemFactory.COLOR)) {
             generatedClass = colorItemClassTemplate.replaceAll("ITEMNAME", item.getName());
         } else if (type.equals(CoreItemFactory.CONTACT)) {
-            generatedClass = openClosedItemClassTemplate.replaceAll("ITEMNAME", item.getName());
+            generatedClass = contactItemClassTemplate.replaceAll("ITEMNAME", item.getName());
         } else if (type.equals(CoreItemFactory.PLAYER)) {
             generatedClass = playerItemClassTemplate.replaceAll("ITEMNAME", item.getName());
         } else if (type.equals(CoreItemFactory.DATETIME)) {

--- a/src/main/java/org/openhab/automation/jrule/items/JRuleItemClassGenerator.java
+++ b/src/main/java/org/openhab/automation/jrule/items/JRuleItemClassGenerator.java
@@ -46,6 +46,7 @@ public class JRuleItemClassGenerator {
     private final URL dateTimeItemClassTemplateUrl;
     private final URL colorItemClassTemplateUrl;
     private final URL contactItemClassTemplateUrl;
+    private final URL rollershutterItemClassTemplateUrl;
     private final URL groupItemClassTemplateUrl;
 
     private final String itemClassTemplate;
@@ -56,6 +57,7 @@ public class JRuleItemClassGenerator {
     private final String stringItemClassTemplate;
     private final String colorItemClassTemplate;
     private final String contactItemClassTemplate;
+    private final String rollershutterItemClassTemplate;
     private final String dateTimeItemClassTemplate;
     private final String groupItemClassTemplate;
 
@@ -78,6 +80,8 @@ public class JRuleItemClassGenerator {
         colorItemClassTemplate = JRuleUtil.getResourceAsString(colorItemClassTemplateUrl);
         contactItemClassTemplateUrl = JRuleUtil.getResourceUrl("ItemClassContact.template");
         contactItemClassTemplate = JRuleUtil.getResourceAsString(contactItemClassTemplateUrl);
+        rollershutterItemClassTemplateUrl = JRuleUtil.getResourceUrl("ItemClassRollershutter.template");
+        rollershutterItemClassTemplate = JRuleUtil.getResourceAsString(rollershutterItemClassTemplateUrl);
         dateTimeItemClassTemplateUrl = JRuleUtil.getResourceUrl("ItemClassDateTime.template");
         dateTimeItemClassTemplate = JRuleUtil.getResourceAsString(dateTimeItemClassTemplateUrl);
         groupItemClassTemplateUrl = JRuleUtil.getResourceUrl("ItemClassGroup.template");
@@ -112,7 +116,7 @@ public class JRuleItemClassGenerator {
         } else if (type.equals(CoreItemFactory.CALL)) {
             generatedClass = itemClassTemplate.replaceAll("ITEMNAME", item.getName());
         } else if (type.equals(CoreItemFactory.ROLLERSHUTTER)) {
-            generatedClass = itemClassTemplate.replaceAll("ITEMNAME", item.getName());
+            generatedClass = rollershutterItemClassTemplate.replaceAll("ITEMNAME", item.getName());
         } else if (type.equals(CoreItemFactory.LOCATION)) {
             generatedClass = itemClassTemplate.replaceAll("ITEMNAME", item.getName());
         } else if (type.equals(CoreItemFactory.COLOR)) {

--- a/src/main/java/org/openhab/automation/jrule/items/JRuleRollershutterItem.java
+++ b/src/main/java/org/openhab/automation/jrule/items/JRuleRollershutterItem.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.automation.jrule.items;
+
+import org.openhab.automation.jrule.internal.handler.JRuleEventHandler;
+import org.openhab.automation.jrule.rules.value.JRuleStopMoveValue;
+import org.openhab.automation.jrule.rules.value.JRuleUpDownValue;
+
+/**
+ * The {@link JRuleRollershutterItem} Items
+ *
+ * @author Timo Litzius - Initial contribution
+ */
+public abstract class JRuleRollershutterItem extends JRuleItem {
+
+    public static int getState(String itemName) {
+        return JRuleEventHandler.get().getStateFromItemAsInt(itemName);
+    }
+
+    public static void sendCommand(String itemName, JRuleUpDownValue command) {
+        JRuleEventHandler.get().sendCommand(itemName, command);
+    }
+
+    public static void sendCommand(String itemName, JRuleStopMoveValue command) {
+        JRuleEventHandler.get().sendCommand(itemName, command);
+    }
+
+    public static void sendCommand(String itemName, int value) {
+        JRuleEventHandler.get().sendCommand(itemName, new JRulePercentType(value));
+    }
+
+    public static void postUpdate(String itemName, JRuleUpDownValue state) {
+        JRuleEventHandler.get().postUpdate(itemName, state);
+    }
+
+    public static void postUpdate(String itemName, int value) {
+        JRuleEventHandler.get().postUpdate(itemName, new JRulePercentType(value));
+    }
+}

--- a/src/main/java/org/openhab/automation/jrule/rules/value/JRuleIncreaseDecreaseValue.java
+++ b/src/main/java/org/openhab/automation/jrule/rules/value/JRuleIncreaseDecreaseValue.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.automation.jrule.rules.value;
+
+/**
+ * The {@link JRuleIncreaseDecreaseValue} JRule Command
+ *
+ * @author Timo Litzius - Initial contribution
+ */
+public enum JRuleIncreaseDecreaseValue {
+    INCREASE,
+    DECREASE,
+    UNDEF
+}

--- a/src/main/java/org/openhab/automation/jrule/rules/value/JRuleOpenClosedValue.java
+++ b/src/main/java/org/openhab/automation/jrule/rules/value/JRuleOpenClosedValue.java
@@ -20,5 +20,15 @@ package org.openhab.automation.jrule.rules.value;
 public enum JRuleOpenClosedValue {
     OPEN,
     CLOSED,
-    UNDEF
+    UNDEF;
+
+    public static JRuleOpenClosedValue getValueFromString(String value) {
+        if (value.equals("OPEN")) {
+            return OPEN;
+        }
+        if (value.equals("CLOSED")) {
+            return CLOSED;
+        }
+        return UNDEF;
+    }
 }

--- a/src/main/java/org/openhab/automation/jrule/rules/value/JRuleStopMoveValue.java
+++ b/src/main/java/org/openhab/automation/jrule/rules/value/JRuleStopMoveValue.java
@@ -13,21 +13,21 @@
 package org.openhab.automation.jrule.rules.value;
 
 /**
- * The {@link JRuleIncreaseDecreaseValue} JRule Command
+ * The {@link JRuleStopMoveValue} JRule Command
  *
- * @author Timo Litzius - Initial contribution
+ * @author Timo Litzius- Initial contribution
  */
-public enum JRuleIncreaseDecreaseValue {
-    INCREASE,
-    DECREASE,
+public enum JRuleStopMoveValue {
+    STOP,
+    MOVE,
     UNDEF;
 
-    public static JRuleIncreaseDecreaseValue getValueFromString(String value) {
-        if (value.equals("INCREASE")) {
-            return INCREASE;
+    public static JRuleStopMoveValue getValueFromString(String value) {
+        if (value.equals("STOP")) {
+            return STOP;
         }
-        if (value.equals("DECREASE")) {
-            return DECREASE;
+        if (value.equals("MOVE")) {
+            return MOVE;
         }
         return UNDEF;
     }

--- a/src/main/java/org/openhab/automation/jrule/rules/value/JRuleUpDownValue.java
+++ b/src/main/java/org/openhab/automation/jrule/rules/value/JRuleUpDownValue.java
@@ -13,21 +13,21 @@
 package org.openhab.automation.jrule.rules.value;
 
 /**
- * The {@link JRuleIncreaseDecreaseValue} JRule Command
+ * The {@link JRuleUpDownValue} JRule Command
  *
- * @author Timo Litzius - Initial contribution
+ * @author Timo Litzius- Initial contribution
  */
-public enum JRuleIncreaseDecreaseValue {
-    INCREASE,
-    DECREASE,
+public enum JRuleUpDownValue {
+    UP,
+    DOWN,
     UNDEF;
 
-    public static JRuleIncreaseDecreaseValue getValueFromString(String value) {
-        if (value.equals("INCREASE")) {
-            return INCREASE;
+    public static JRuleUpDownValue getValueFromString(String value) {
+        if (value.equals("UP")) {
+            return UP;
         }
-        if (value.equals("DECREASE")) {
-            return DECREASE;
+        if (value.equals("DOWN")) {
+            return DOWN;
         }
         return UNDEF;
     }

--- a/src/main/resources/ItemClassColor.template
+++ b/src/main/resources/ItemClassColor.template
@@ -15,6 +15,7 @@ package org.openhab.automation.jrule.items.generated;
 import org.openhab.automation.jrule.items.JRuleColorItem;
 import org.openhab.automation.jrule.rules.value.JRuleColorValue;
 import org.openhab.automation.jrule.rules.value.JRuleOnOffValue;
+import org.openhab.automation.jrule.rules.value.JRuleIncreaseDecreaseValue;
 
 /**
  * Automatically Generated Class
@@ -43,6 +44,10 @@ public class _ITEMNAME extends JRuleColorItem {
     }
 
     public static void sendCommand(JRuleOnOffValue command) {
+        JRuleColorItem.sendCommand(ITEM, command);
+    }
+
+    public static void sendCommand(JRuleIncreaseDecreaseValue command) {
         JRuleColorItem.sendCommand(ITEM, command);
     }
 

--- a/src/main/resources/ItemClassColor.template
+++ b/src/main/resources/ItemClassColor.template
@@ -14,6 +14,7 @@ package org.openhab.automation.jrule.items.generated;
 
 import org.openhab.automation.jrule.items.JRuleColorItem;
 import org.openhab.automation.jrule.rules.value.JRuleColorValue;
+import org.openhab.automation.jrule.rules.value.JRuleOnOffValue;
 
 /**
  * Automatically Generated Class
@@ -28,12 +29,36 @@ public class _ITEMNAME extends JRuleColorItem {
     public static JRuleColorValue getState() {
         return JRuleColorItem.getState(ITEM);
     }
+
+    public static JRuleOnOffValue getOnOffState() {
+        return JRuleColorItem.getOnOffState(ITEM);
+    }
+
+    public static int getPercentState() {
+        return JRuleColorItem.getPercentState(ITEM);
+    }
     
     public static void sendCommand(JRuleColorValue command) {
         JRuleColorItem.sendCommand(ITEM, command);
     }
 
+    public static void sendCommand(JRuleOnOffValue command) {
+        JRuleColorItem.sendCommand(ITEM, command);
+    }
+
+    public static void sendCommand(int value) {
+        JRuleColorItem.sendCommand(ITEM, value);
+    }
+
     public static void postUpdate(JRuleColorValue value) {
+        JRuleColorItem.postUpdate(ITEM, value);
+    }
+
+    public static void postUpdate(JRuleOnOffValue value) {
+        JRuleColorItem.postUpdate(ITEM, value);
+    }
+
+    public static void postUpdate(int value) {
         JRuleColorItem.postUpdate(ITEM, value);
     }
 }

--- a/src/main/resources/ItemClassContact.template
+++ b/src/main/resources/ItemClassContact.template
@@ -12,7 +12,7 @@
  */
 package org.openhab.automation.jrule.items.generated;
 
-import org.openhab.automation.jrule.items.JRuleOpenClosedItem;
+import org.openhab.automation.jrule.items.JRuleContactItem;
 import org.openhab.automation.jrule.rules.value.JRuleOpenClosedValue;
 
 /**
@@ -21,7 +21,7 @@ import org.openhab.automation.jrule.rules.value.JRuleOpenClosedValue;
  *
  * @author Timo Litzius - Initial contribution
  */
-public class _ITEMNAME extends JRuleOpenClosedItem {
+public class _ITEMNAME extends JRuleContactItem {
  
     public static final String ITEM = "ITEMNAME";
     

--- a/src/main/resources/ItemClassDimmer.template
+++ b/src/main/resources/ItemClassDimmer.template
@@ -14,6 +14,7 @@ package org.openhab.automation.jrule.items.generated;
 
 import org.openhab.automation.jrule.items.JRuleDimmerItem;
 import org.openhab.automation.jrule.rules.value.JRuleOnOffValue;
+import org.openhab.automation.jrule.rules.value.JRuleIncreaseDecreaseValue;
 
 /**
  * Automatically Generated Class
@@ -30,6 +31,10 @@ public class _ITEMNAME extends JRuleDimmerItem {
     }
     
     public static void sendCommand(JRuleOnOffValue command) {
+        JRuleDimmerItem.sendCommand(ITEM, command);
+    }
+
+    public static void sendCommand(JRuleIncreaseDecreaseValue command) {
         JRuleDimmerItem.sendCommand(ITEM, command);
     }
 

--- a/src/main/resources/ItemClassRollershutter.template
+++ b/src/main/resources/ItemClassRollershutter.template
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.automation.jrule.items.generated;
+
+import org.openhab.automation.jrule.items.JRuleRollershutterItem;
+import org.openhab.automation.jrule.rules.value.JRuleStopMoveValue;
+import org.openhab.automation.jrule.rules.value.JRuleUpDownValue;
+
+/**
+ * Automatically Generated Class
+ * The {@link _ITEMNAME} 
+ *
+ * @author Timo Litzius - Initial contribution
+ */
+public class _ITEMNAME extends JRuleRollershutterItem {
+ 
+    public static final String ITEM = "ITEMNAME";
+    
+    public static int getState() {
+        return JRuleRollershutterItem.getState(ITEM);
+    }
+
+    public static void sendCommand(JRuleUpDownValue command) {
+        JRuleRollershutterItem.sendCommand(ITEM, command);
+    }
+
+    public static void sendCommand(JRuleStopMoveValue command) {
+        JRuleRollershutterItem.sendCommand(ITEM, command);
+    }
+
+    public static void sendCommand(int value) {
+        JRuleRollershutterItem.sendCommand(ITEM, value);
+    }
+
+    public static void postUpdate(JRuleUpDownValue command) {
+        JRuleRollershutterItem.postUpdate(ITEM, command);
+    }
+
+    public static void postUpdate(int value) {
+        JRuleRollershutterItem.postUpdate(ITEM, value);
+    }
+}


### PR DESCRIPTION
This PR adds support for the following to be more complete according to the [docs](https://www.openhab.org/docs/configuration/items.html#type):
* Color (changed)
  * OnOff (command, state)
  * IncreaseDecrease (command)
  * Percent (command, state)
* Dimmer (changed)
  * IncreaseDecrease (command)
* Rollershutter (new)
  * UpDown (command)
  * StopMove (command)
  * Percent (command, state)

As you already correctly noticed in my last PR, the naming of `OpenClosedItem` was questionable, so I renamed it to `ContactItem` for consistency.

`ColorItem` got 2 additional methods as the state can be expressed in multiple ways: 
* `getOnOffState`
* `getPercentState`

Maybe you have a suggestion on how to do that differently. That was just my first idea.
`IncreaseDecrease` and `StopMove` commands cannot be used within postUpdate as they don't implement `State`.
I made multiple commits so you can see the changes more easily.
