### PR TITLE
Fix ItemClassContact.template and extend JRuleEvent

### DIFF
--- a/src/main/java/org/openhab/automation/jrule/rules/JRuleEvent.java
+++ b/src/main/java/org/openhab/automation/jrule/rules/JRuleEvent.java
@@ -13,6 +13,8 @@
 package org.openhab.automation.jrule.rules;
 
 import org.openhab.automation.jrule.rules.value.JRuleOnOffValue;
+import org.openhab.automation.jrule.rules.value.JRuleOpenClosedValue;
+import org.openhab.automation.jrule.rules.value.JRuleUpDownValue;
 
 /**
  * The {@link JRuleEvent}
@@ -40,6 +42,14 @@ public class JRuleEvent {
 
     public JRuleOnOffValue getValueAsOnOffValue() {
         return JRuleOnOffValue.getValueFromString(value);
+    }
+
+    public JRuleOpenClosedValue getValueAsOpenClosedValue() {
+        return JRuleOpenClosedValue.getValueFromString(value);
+    }
+
+    public JRuleUpDownValue getValueAsUpDownValue() {
+        return JRuleUpDownValue.getValueFromString(value);
     }
 
     public Double getValueAsDouble() {

--- a/src/main/resources/ItemClassContact.template
+++ b/src/main/resources/ItemClassContact.template
@@ -26,6 +26,6 @@ public class _ITEMNAME extends JRuleContactItem {
     public static final String ITEM = "ITEMNAME";
     
     public static JRuleOpenClosedValue getState() {
-        return JRuleOpenClosedItem.getState(ITEM);
+        return JRuleContactItem.getState(ITEM);
     }
 }


### PR DESCRIPTION
This fixes a compilation error of the ContactItem which was introduced by renaming.
For convenience I also extended the JRuleEvent class with OpenClosedValue and UpDownValue.