### PR TITLE
Fix Windows support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ will be automatically compiled and loaded into OpenHAB when the addon is started
 
 # Limitations
 
-- Currently, only working for OpenHAB installations under Linux / Unix Operating Systems, not supported in Windows (for rules development it's fine to use windows)
 - Not supporting OH3 GUI rules, script actions and script conditions 
 
 # Why?

--- a/pom.xml
+++ b/pom.xml
@@ -26,4 +26,44 @@
       <optional>true</optional>
     </dependency>
   </dependencies>
+
+  <repositories>
+    <repository>
+      <id>openhab-release</id>
+      <url>https://openhab.jfrog.io/artifactory/libs-release</url>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </repository>
+    <repository>
+      <id>openhab-snapshot</id>
+      <url>https://openhab.jfrog.io/artifactory/libs-snapshot</url>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
+
+  <profiles>
+    <profile>
+      <id>standalone</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.commonjava.maven.plugins</groupId>
+            <artifactId>directory-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>directories</id>
+                <phase>none</phase>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/src/main/java/org/openhab/automation/jrule/internal/JRuleConfig.java
+++ b/src/main/java/org/openhab/automation/jrule/internal/JRuleConfig.java
@@ -101,7 +101,7 @@ public class JRuleConfig {
     public String getItemsDirectory() {
         final StringBuilder sb = new StringBuilder(getWorkingDirectory());
         sb.append(File.separator).append(ITEMS_DIR_START).append(File.separator);
-        final String p = getGeneratedItemPackage().replaceAll("\\.", File.separator);
+        final String p = JRuleUtil.packageNameToPath(getGeneratedItemPackage());
         sb.append(p);
         return sb.toString();
     }

--- a/src/main/java/org/openhab/automation/jrule/internal/JRuleFactory.java
+++ b/src/main/java/org/openhab/automation/jrule/internal/JRuleFactory.java
@@ -73,7 +73,7 @@ public class JRuleFactory {
         config.initConfig();
         jRuleEngine = JRuleEngine.get();
         jRuleEngine.setConfig(config);
-        jRuleHandler = new JRuleHandler(properties, itemRegistry, eventPublisher, eventSubscriber, voiceManager,
+        jRuleHandler = new JRuleHandler(config, itemRegistry, eventPublisher, eventSubscriber, voiceManager,
                 componentContext.getBundleContext());
         createDelayedInitialization(getInitDelaySeconds(properties));
     }

--- a/src/main/java/org/openhab/automation/jrule/internal/JRuleUtil.java
+++ b/src/main/java/org/openhab/automation/jrule/internal/JRuleUtil.java
@@ -234,4 +234,8 @@ public class JRuleUtil {
         }
         return end > 0 && end > start ? topic.substring(start, end) : JRuleConstants.EMPTY;
     }
+
+    public static String packageNameToPath(String packageName) {
+        return packageName.replace('.', File.separatorChar);
+    }
 }

--- a/src/main/java/org/openhab/automation/jrule/internal/JRuleUtil.java
+++ b/src/main/java/org/openhab/automation/jrule/internal/JRuleUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2021 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
@@ -13,24 +13,15 @@
 package org.openhab.automation.jrule.internal;
 
 import java.io.BufferedInputStream;
-import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.net.FileNameMap;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.net.URL;
-import java.net.URLConnection;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.util.ArrayList;
-import java.util.Enumeration;
-import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
@@ -153,72 +144,6 @@ public class JRuleUtil {
 
     public static boolean isNotEmpty(String oldValue) {
         return oldValue != null && !oldValue.isEmpty();
-    }
-
-    @SuppressWarnings("rawtypes")
-    public static Class[] getClasses(String packageName) throws ClassNotFoundException, IOException {
-        final ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
-        if (classLoader == null) {
-            throw new ClassNotFoundException("Could not get classloder");
-        }
-        final String pathFromPackage = packageName.replace('.', '/');
-        final Enumeration<URL> resources = classLoader.getResources(pathFromPackage);
-        JRuleLog.debug(logger, LOG_NAME_UTIL, "Get ResClasses enum: {}", resources.hasMoreElements());
-        final List<File> dirs = new ArrayList<File>();
-        while (resources.hasMoreElements()) {
-            final URL resource = resources.nextElement();
-            final URLConnection connection = resource.openConnection();
-            InputStream openStream = connection.getInputStream();
-            BufferedReader reader = new BufferedReader(new InputStreamReader(openStream));
-            String line = null;
-            while ((line = reader.readLine()) != null) {
-                JRuleLog.debug(logger, LOG_NAME_UTIL, "line: {}", line);
-            }
-            final FileNameMap fileNameMap = URLConnection.getFileNameMap();
-            URI uri;
-            try {
-                uri = connection.getURL().toURI();
-                JRuleLog.debug(logger, LOG_NAME_UTIL, "Uri: {}", uri.toString());
-            } catch (URISyntaxException e) {
-                JRuleLog.debug(logger, LOG_NAME_UTIL, "Uri syntax exception", e);
-            }
-            dirs.add(new File(resource.getFile()));
-        }
-        ArrayList<Class> classes = new ArrayList<>();
-        for (File directory : dirs) {
-            classes.addAll(findClasses(directory, packageName));
-        }
-        return classes.toArray(new Class[classes.size()]);
-    }
-
-    /**
-     * Recursive method used to find all classes in a given directory and subdirs.
-     *
-     * @param directory The base directory
-     * @param packageName The package name for classes found inside the base directory
-     * @return The classes
-     * @throws ClassNotFoundException
-     */
-    @SuppressWarnings("rawtypes")
-    private static List<Class> findClasses(File directory, String packageName) throws ClassNotFoundException {
-        final List<Class> classes = new ArrayList<>();
-        if (!directory.exists()) {
-            return classes;
-        }
-        final File[] files = directory.listFiles();
-        for (File file : files) {
-            if (file.isDirectory()) {
-                if (file.getName().contains(".")) {
-                    // LOgger warn
-                    continue;
-                }
-                classes.addAll(findClasses(file, packageName + "." + file.getName()));
-            } else if (file.getName().endsWith(JRuleConstants.CLASS_FILE_TYPE)) {
-                classes.add(Class.forName(packageName + '.' + file.getName().substring(0, file.getName().length() - 6),
-                        false, JRuleUtil.class.getClassLoader()));
-            }
-        }
-        return classes;
     }
 
     public static String getFileAsString(File file) {


### PR DESCRIPTION
Fixed the startup problem on Windows.
Basically it was a problem with the string replace, because the windows separator "\" is interpreted as escape sequence in the replace. This fails because no character exists to be escaped.
E.g.:
`System.out.println("asd.fgh".replaceAll("\\.", "\\"));` fails
`System.out.println("asd.fgh".replaceAll("\\.", "\\\\"));` suceeds

In addition, I fixed a compile problem, and made the project buildable, without any additional configuration.