### PR TITLE
Set ms part to 0 to avoid rescheduled timer executing multiple times …

### DIFF
--- a/src/main/java/org/openhab/automation/jrule/internal/engine/JRuleEngine.java
+++ b/src/main/java/org/openhab/automation/jrule/internal/engine/JRuleEngine.java
@@ -244,6 +244,7 @@ public class JRuleEngine implements PropertyChangeListener {
         calFuture.set(Calendar.HOUR_OF_DAY, hours == -1 ? 0 : hours);
         calFuture.set(Calendar.MINUTE, minutes == -1 ? 0 : minutes);
         calFuture.set(Calendar.SECOND, seconds == -1 ? 0 : seconds);
+        calFuture.set(Calendar.MILLISECOND, 0);
         calFuture.set(Calendar.HOUR_OF_DAY, hours);
         if (calFuture.before(now)) {
             if (hours != -1) {


### PR DESCRIPTION
…within second. NB only works on slower computers that cannot execute the rule within a single ms

Possible fix for #21 