### PR TITLE
Wrap TransformationException in JRuleExecutionException

### DIFF
--- a/src/main/java/org/openhab/automation/jrule/JRuleExecutionException.java
+++ b/src/main/java/org/openhab/automation/jrule/JRuleExecutionException.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.automation.jrule;
+
+/**
+ * The {@link JRuleExecutionException} wraps underlying openHAB exceptions
+ *
+ * @author Arne Seime - Initial contribution
+ */
+public class JRuleExecutionException extends Exception {
+    public JRuleExecutionException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/org/openhab/automation/jrule/internal/handler/JRuleTransformationHandler.java
+++ b/src/main/java/org/openhab/automation/jrule/internal/handler/JRuleTransformationHandler.java
@@ -12,6 +12,7 @@
  */
 package org.openhab.automation.jrule.internal.handler;
 
+import org.openhab.automation.jrule.JRuleExecutionException;
 import org.openhab.core.transform.TransformationException;
 import org.openhab.core.transform.TransformationHelper;
 import org.osgi.framework.BundleContext;
@@ -49,7 +50,12 @@ public class JRuleTransformationHandler {
         this.bundleContext = bundleContext;
     }
 
-    public String transform(String stateDescPattern, String state) throws TransformationException {
-        return TransformationHelper.transform(bundleContext, stateDescPattern, state);
+    public String transform(String stateDescPattern, String state) throws JRuleExecutionException {
+        try {
+            return TransformationHelper.transform(bundleContext, stateDescPattern, state);
+        } catch (TransformationException e) {
+            throw new JRuleExecutionException(
+                    String.format("Transformation of %s using %s failed: %s", state, stateDescPattern, e.toString()));
+        }
     }
 }

--- a/src/main/java/org/openhab/automation/jrule/rules/JRule.java
+++ b/src/main/java/org/openhab/automation/jrule/rules/JRule.java
@@ -24,6 +24,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
+import org.openhab.automation.jrule.JRuleExecutionException;
 import org.openhab.automation.jrule.internal.JRuleLog;
 import org.openhab.automation.jrule.internal.JRuleUtil;
 import org.openhab.automation.jrule.internal.engine.JRuleEngine;
@@ -33,7 +34,6 @@ import org.openhab.automation.jrule.internal.handler.JRuleTransformationHandler;
 import org.openhab.automation.jrule.internal.handler.JRuleVoiceHandler;
 import org.openhab.automation.jrule.items.JRulePercentType;
 import org.openhab.automation.jrule.rules.value.JRuleOnOffValue;
-import org.openhab.core.transform.TransformationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -182,7 +182,7 @@ public class JRule {
         JRuleVoiceHandler.get().say(text);
     }
 
-    protected String transform(String stateDescPattern, String state) throws TransformationException {
+    protected String transform(String stateDescPattern, String state) throws JRuleExecutionException {
         return JRuleTransformationHandler.get().transform(stateDescPattern, state);
     }
 


### PR DESCRIPTION
TransformationException is not available for rules, so this PR wraps it in a new JRuleExecutionException.

IMHO all underlying exceptions occuring during rules execution should be wrapped and error message made available. This helps the user to figure out what's wrong.

Fixes https://community.openhab.org/t/jrule-openhab-rules-using-java/121441/105