### PR TITLE
Add item id to generated items

### DIFF
--- a/src/main/java/org/openhab/automation/jrule/items/JRuleCallItem.java
+++ b/src/main/java/org/openhab/automation/jrule/items/JRuleCallItem.java
@@ -21,7 +21,7 @@ import org.openhab.automation.jrule.internal.handler.JRuleEventHandler;
  *
  * @author Arne Seime - Initial contribution
  */
-public class JRuleCallItem extends JRuleItem {
+public abstract class JRuleCallItem extends JRuleItem {
 
     protected JRuleCallItem(String itemName) {
         super(itemName);

--- a/src/main/java/org/openhab/automation/jrule/items/JRuleColorItem.java
+++ b/src/main/java/org/openhab/automation/jrule/items/JRuleColorItem.java
@@ -24,7 +24,7 @@ import org.openhab.automation.jrule.rules.value.JRuleOnOffValue;
  *
  * @author Joseph (Seaside) Hagberg - Initial contribution
  */
-public class JRuleColorItem extends JRuleItem {
+public abstract class JRuleColorItem extends JRuleItem {
 
     protected JRuleColorItem(String itemName) {
         super(itemName);

--- a/src/main/java/org/openhab/automation/jrule/items/JRuleContactItem.java
+++ b/src/main/java/org/openhab/automation/jrule/items/JRuleContactItem.java
@@ -23,7 +23,7 @@ import org.openhab.automation.jrule.trigger.JRuleContactTrigger;
  *
  * @author Timo Litzius - Initial contribution
  */
-public class JRuleContactItem extends JRuleItem implements JRuleContactTrigger {
+public abstract class JRuleContactItem extends JRuleItem implements JRuleContactTrigger {
 
     protected JRuleContactItem(String itemName) {
         super(itemName);

--- a/src/main/java/org/openhab/automation/jrule/items/JRuleDateTimeItem.java
+++ b/src/main/java/org/openhab/automation/jrule/items/JRuleDateTimeItem.java
@@ -22,7 +22,7 @@ import org.openhab.automation.jrule.internal.handler.JRuleEventHandler;
  *
  * @author Joseph (Seaside) Hagberg - Initial contribution
  */
-public class JRuleDateTimeItem extends JRuleItem {
+public abstract class JRuleDateTimeItem extends JRuleItem {
 
     protected JRuleDateTimeItem(String itemName) {
         super(itemName);

--- a/src/main/java/org/openhab/automation/jrule/items/JRuleDimmerItem.java
+++ b/src/main/java/org/openhab/automation/jrule/items/JRuleDimmerItem.java
@@ -24,7 +24,7 @@ import org.openhab.automation.jrule.trigger.JRuleDimmerTrigger;
  *
  * @author Joseph (Seaside) Hagberg - Initial contribution
  */
-public class JRuleDimmerItem extends JRuleItem implements JRuleDimmerTrigger {
+public abstract class JRuleDimmerItem extends JRuleItem implements JRuleDimmerTrigger {
 
     protected JRuleDimmerItem(String itemName) {
         super(itemName);

--- a/src/main/java/org/openhab/automation/jrule/items/JRuleGroupCallItem.java
+++ b/src/main/java/org/openhab/automation/jrule/items/JRuleGroupCallItem.java
@@ -21,7 +21,7 @@ import org.openhab.automation.jrule.internal.handler.JRuleEventHandler;
  *
  * @author Arne Seime - Initial contribution
  */
-public class JRuleGroupCallItem extends JRuleGroupItem {
+public abstract class JRuleGroupCallItem extends JRuleGroupItem {
 
     protected JRuleGroupCallItem(String itemName) {
         super(itemName);

--- a/src/main/java/org/openhab/automation/jrule/items/JRuleGroupColorItem.java
+++ b/src/main/java/org/openhab/automation/jrule/items/JRuleGroupColorItem.java
@@ -25,7 +25,7 @@ import org.openhab.automation.jrule.rules.value.JRuleOnOffValue;
  *
  * @author Arne Seime - Initial contribution
  */
-public class JRuleGroupColorItem extends JRuleGroupItem {
+public abstract class JRuleGroupColorItem extends JRuleGroupItem {
 
     protected JRuleGroupColorItem(String itemName) {
         super(itemName);

--- a/src/main/java/org/openhab/automation/jrule/items/JRuleGroupContactItem.java
+++ b/src/main/java/org/openhab/automation/jrule/items/JRuleGroupContactItem.java
@@ -23,7 +23,7 @@ import org.openhab.automation.jrule.rules.value.JRuleOpenClosedValue;
  *
  * @author Arne Seime - Initial contribution
  */
-public class JRuleGroupContactItem extends JRuleGroupItem {
+public abstract class JRuleGroupContactItem extends JRuleGroupItem {
 
     protected JRuleGroupContactItem(String itemName) {
         super(itemName);

--- a/src/main/java/org/openhab/automation/jrule/items/JRuleGroupDateTimeItem.java
+++ b/src/main/java/org/openhab/automation/jrule/items/JRuleGroupDateTimeItem.java
@@ -23,7 +23,7 @@ import org.openhab.automation.jrule.internal.handler.JRuleEventHandler;
  *
  * @author Arne Seime - Initial contribution
  */
-public class JRuleGroupDateTimeItem extends JRuleGroupItem {
+public abstract class JRuleGroupDateTimeItem extends JRuleGroupItem {
 
     protected JRuleGroupDateTimeItem(String itemName) {
         super(itemName);

--- a/src/main/java/org/openhab/automation/jrule/items/JRuleGroupDimmerItem.java
+++ b/src/main/java/org/openhab/automation/jrule/items/JRuleGroupDimmerItem.java
@@ -28,7 +28,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Arne Seime - Initial contribution
  */
-public class JRuleGroupDimmerItem extends JRuleGroupItem implements JRuleDimmerTrigger {
+public abstract class JRuleGroupDimmerItem extends JRuleGroupItem implements JRuleDimmerTrigger {
 
     private static final String LOG_NAME = "JRuleGroupDimmerItem";
     private static final Logger logger = LoggerFactory.getLogger(JRuleGroupDimmerItem.class);

--- a/src/main/java/org/openhab/automation/jrule/items/JRuleGroupImageItem.java
+++ b/src/main/java/org/openhab/automation/jrule/items/JRuleGroupImageItem.java
@@ -21,7 +21,7 @@ import org.openhab.automation.jrule.internal.handler.JRuleEventHandler;
  *
  * @author Arne Seime - Initial contribution
  */
-public class JRuleGroupImageItem extends JRuleGroupItem {
+public abstract class JRuleGroupImageItem extends JRuleGroupItem {
 
     protected JRuleGroupImageItem(String itemName) {
         super(itemName);

--- a/src/main/java/org/openhab/automation/jrule/items/JRuleGroupLocationItem.java
+++ b/src/main/java/org/openhab/automation/jrule/items/JRuleGroupLocationItem.java
@@ -21,7 +21,7 @@ import org.openhab.automation.jrule.internal.handler.JRuleEventHandler;
  *
  * @author Arne Seime - Initial contribution
  */
-public class JRuleGroupLocationItem extends JRuleGroupItem {
+public abstract class JRuleGroupLocationItem extends JRuleGroupItem {
 
     protected JRuleGroupLocationItem(String itemName) {
         super(itemName);

--- a/src/main/java/org/openhab/automation/jrule/items/JRuleGroupNumberItem.java
+++ b/src/main/java/org/openhab/automation/jrule/items/JRuleGroupNumberItem.java
@@ -25,7 +25,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Arne Seime - Initial contribution
  */
-public class JRuleGroupNumberItem extends JRuleGroupItem {
+public abstract class JRuleGroupNumberItem extends JRuleGroupItem {
 
     private static final String LOG_NAME = "JRuleGroupNumberItem";
     private static final Logger logger = LoggerFactory.getLogger(JRuleGroupNumberItem.class);

--- a/src/main/java/org/openhab/automation/jrule/items/JRuleGroupPlayerItem.java
+++ b/src/main/java/org/openhab/automation/jrule/items/JRuleGroupPlayerItem.java
@@ -25,7 +25,7 @@ import org.openhab.core.library.types.PlayPauseType;
  *
  * @author Arne Seime - Initial contribution
  */
-public class JRuleGroupPlayerItem extends JRuleGroupItem implements JRulePlayerTrigger {
+public abstract class JRuleGroupPlayerItem extends JRuleGroupItem implements JRulePlayerTrigger {
 
     protected JRuleGroupPlayerItem(String itemName) {
         super(itemName);

--- a/src/main/java/org/openhab/automation/jrule/items/JRuleGroupRollershutterItem.java
+++ b/src/main/java/org/openhab/automation/jrule/items/JRuleGroupRollershutterItem.java
@@ -23,7 +23,7 @@ import org.openhab.automation.jrule.rules.value.JRuleUpDownValue;
  *
  * @author Arne Seime - Initial contribution
  */
-public class JRuleGroupRollershutterItem extends JRuleGroupItem {
+public abstract class JRuleGroupRollershutterItem extends JRuleGroupItem {
 
     protected JRuleGroupRollershutterItem(String itemName) {
         super(itemName);

--- a/src/main/java/org/openhab/automation/jrule/items/JRuleGroupStringItem.java
+++ b/src/main/java/org/openhab/automation/jrule/items/JRuleGroupStringItem.java
@@ -21,7 +21,7 @@ import org.openhab.automation.jrule.internal.handler.JRuleEventHandler;
  *
  * @author Arne Seime - Initial contribution
  */
-public class JRuleGroupStringItem extends JRuleGroupItem {
+public abstract class JRuleGroupStringItem extends JRuleGroupItem {
 
     protected JRuleGroupStringItem(String itemName) {
         super(itemName);

--- a/src/main/java/org/openhab/automation/jrule/items/JRuleGroupSwitchItem.java
+++ b/src/main/java/org/openhab/automation/jrule/items/JRuleGroupSwitchItem.java
@@ -24,7 +24,7 @@ import org.openhab.automation.jrule.trigger.JRuleSwitchTrigger;
  *
  * @author Arne Seime - Initial contribution
  */
-public class JRuleGroupSwitchItem extends JRuleGroupItem implements JRuleSwitchTrigger {
+public abstract class JRuleGroupSwitchItem extends JRuleGroupItem implements JRuleSwitchTrigger {
 
     protected JRuleGroupSwitchItem(String itemName) {
         super(itemName);

--- a/src/main/java/org/openhab/automation/jrule/items/JRuleImageItem.java
+++ b/src/main/java/org/openhab/automation/jrule/items/JRuleImageItem.java
@@ -22,7 +22,7 @@ import org.openhab.automation.jrule.rules.value.JRuleRawValue;
  *
  * @author Arne Seime - Initial contribution
  */
-public class JRuleImageItem extends JRuleItem {
+public abstract class JRuleImageItem extends JRuleItem {
 
     protected JRuleImageItem(String itemName) {
         super(itemName);

--- a/src/main/java/org/openhab/automation/jrule/items/JRuleItem.java
+++ b/src/main/java/org/openhab/automation/jrule/items/JRuleItem.java
@@ -33,13 +33,11 @@ public abstract class JRuleItem implements JRuleCommonTrigger {
         return itemName;
     }
 
-    public String getLabel() {
-        return null; // Method overridden by generated item
-    }
+    public abstract String getLabel();
 
-    public String getType() {
-        return null; // Method overridden by generated item
-    }
+    public abstract String getType();
+
+    public abstract String getId();
 
     public ZonedDateTime lastUpdated() {
         return lastUpdated(null);

--- a/src/main/java/org/openhab/automation/jrule/items/JRuleItemClassGenerator.java
+++ b/src/main/java/org/openhab/automation/jrule/items/JRuleItemClassGenerator.java
@@ -150,6 +150,7 @@ public class JRuleItemClassGenerator {
 
     private Map<String, Object> createItemModel(Item item) {
         Map<String, Object> itemModel = new HashMap<>();
+        itemModel.put("id", item.getUID());
         itemModel.put("name", item.getName());
         itemModel.put("package", jRuleConfig.getGeneratedItemPackage());
         itemModel.put("class", jRuleConfig.getGeneratedItemPrefix() + item.getName());

--- a/src/main/java/org/openhab/automation/jrule/items/JRuleLocationItem.java
+++ b/src/main/java/org/openhab/automation/jrule/items/JRuleLocationItem.java
@@ -17,7 +17,7 @@ package org.openhab.automation.jrule.items;
  *
  * @author Arne Seime - Initial contribution
  */
-public class JRuleLocationItem extends JRuleItem {
+public abstract class JRuleLocationItem extends JRuleItem {
 
     protected JRuleLocationItem(String itemName) {
         super(itemName);

--- a/src/main/java/org/openhab/automation/jrule/items/JRuleNumberItem.java
+++ b/src/main/java/org/openhab/automation/jrule/items/JRuleNumberItem.java
@@ -22,7 +22,7 @@ import org.openhab.core.library.types.DecimalType;
  *
  * @author Joseph (Seaside) Hagberg - Initial contribution
  */
-public class JRuleNumberItem extends JRuleItem {
+public abstract class JRuleNumberItem extends JRuleItem {
 
     protected JRuleNumberItem(String itemName) {
         super(itemName);

--- a/src/main/java/org/openhab/automation/jrule/items/JRulePlayerItem.java
+++ b/src/main/java/org/openhab/automation/jrule/items/JRulePlayerItem.java
@@ -23,7 +23,7 @@ import org.openhab.automation.jrule.trigger.JRulePlayerTrigger;
  *
  * @author Joseph (Seaside) Hagberg - Initial contribution
  */
-public class JRulePlayerItem extends JRuleItem implements JRulePlayerTrigger {
+public abstract class JRulePlayerItem extends JRuleItem implements JRulePlayerTrigger {
 
     protected JRulePlayerItem(String itemName) {
         super(itemName);

--- a/src/main/java/org/openhab/automation/jrule/items/JRuleRollershutterItem.java
+++ b/src/main/java/org/openhab/automation/jrule/items/JRuleRollershutterItem.java
@@ -23,7 +23,7 @@ import org.openhab.automation.jrule.rules.value.JRuleUpDownValue;
  *
  * @author Timo Litzius - Initial contribution
  */
-public class JRuleRollershutterItem extends JRuleItem {
+public abstract class JRuleRollershutterItem extends JRuleItem {
 
     protected JRuleRollershutterItem(String itemName) {
         super(itemName);

--- a/src/main/java/org/openhab/automation/jrule/items/JRuleStringItem.java
+++ b/src/main/java/org/openhab/automation/jrule/items/JRuleStringItem.java
@@ -21,7 +21,7 @@ import org.openhab.automation.jrule.internal.handler.JRuleEventHandler;
  *
  * @author Joseph (Seaside) Hagberg - Initial contribution
  */
-public class JRuleStringItem extends JRuleItem {
+public abstract class JRuleStringItem extends JRuleItem {
 
     protected JRuleStringItem(String itemName) {
         super(itemName);

--- a/src/main/java/org/openhab/automation/jrule/items/JRuleSwitchItem.java
+++ b/src/main/java/org/openhab/automation/jrule/items/JRuleSwitchItem.java
@@ -23,7 +23,7 @@ import org.openhab.automation.jrule.trigger.JRuleSwitchTrigger;
  *
  * @author Joseph (Seaside) Hagberg - Initial contribution
  */
-public class JRuleSwitchItem extends JRuleItem implements JRuleSwitchTrigger {
+public abstract class JRuleSwitchItem extends JRuleItem implements JRuleSwitchTrigger {
 
     protected JRuleSwitchItem(String itemName) {
         super(itemName);

--- a/src/main/resources/templates/CommonMethods.ftlh
+++ b/src/main/resources/templates/CommonMethods.ftlh
@@ -4,6 +4,8 @@
 
     public static final String TYPE = "${item.type}";
 
+    public static final String ID = "${item.id}";
+
     @Override
     public String getLabel() {
         return LABEL;
@@ -12,6 +14,11 @@
     @Override
     public String getType() {
         return TYPE;
+    }
+
+    @Override
+    public String getId() {
+        return ID;
     }
 
     @Override


### PR DESCRIPTION
Added the item ID to the generated items. Also made the item classes abstract, so any missing implementation becomes directly visible, and is not hidden by the default implementation returning null.

For some reason the `org.openhab.binding.jrule.internal.JRuleClassGeneratorTest#testGenerateItemsFile` test is not passing for me, even though I can't make out the problem.