### PR TITLE
Memberof trigger

### DIFF
--- a/README.md
+++ b/README.md
@@ -690,6 +690,19 @@ public void sendPushover(JRuleEvent event) {
 }
 ```
 
+## Example 35
+
+Use case: Want to listen on all Item events of a group (without the groupstate must change)
+
+```java
+    @JRuleName("MemberOfUpdateTrigger")
+    @JRuleWhenItemReceivedUpdate(item = _MySwitchGroup.ITEM, memberOf = true)
+    public synchronized void memberOfUpdateTrigger(JRuleItemEvent event) {
+        final String memberThatChangedStatus = event.getMemberName();
+        logInfo("Member that changed the status of the Group of switches: {}", memberThatChangedStatus);
+    }
+```
+
 
 # Changelog
 ## NEXT

--- a/src/main/java/org/openhab/automation/jrule/internal/engine/JRuleEngine.java
+++ b/src/main/java/org/openhab/automation/jrule/internal/engine/JRuleEngine.java
@@ -67,6 +67,7 @@ import org.openhab.core.events.AbstractEvent;
 import org.openhab.core.items.Item;
 import org.openhab.core.items.ItemNotFoundException;
 import org.openhab.core.items.ItemRegistry;
+import org.openhab.core.items.events.ItemEvent;
 import org.openhab.core.library.types.QuantityType;
 import org.openhab.core.scheduler.CronScheduler;
 import org.slf4j.Logger;
@@ -160,7 +161,8 @@ public class JRuleEngine implements PropertyChangeListener {
         Arrays.stream(method.getAnnotationsByType(JRuleWhenItemReceivedUpdate.class)).forEach(jRuleWhen -> {
             JRuleCondition jRuleCondition = jRuleWhen.condition();
             addToContext(new JRuleItemReceivedUpdateExecutionContext(jRule, logName, loggingTags, method,
-                    jRuleWhen.item(), Optional.of(jRuleCondition.lt()).filter(aDouble -> aDouble != Double.MIN_VALUE),
+                    jRuleWhen.item(), jRuleWhen.memberOf(),
+                    Optional.of(jRuleCondition.lt()).filter(aDouble -> aDouble != Double.MIN_VALUE),
                     Optional.of(jRuleCondition.lte()).filter(aDouble -> aDouble != Double.MIN_VALUE),
                     Optional.of(jRuleCondition.gt()).filter(aDouble -> aDouble != Double.MIN_VALUE),
                     Optional.of(jRuleCondition.gte()).filter(aDouble -> aDouble != Double.MIN_VALUE),
@@ -174,7 +176,8 @@ public class JRuleEngine implements PropertyChangeListener {
         Arrays.stream(method.getAnnotationsByType(JRuleWhenItemReceivedCommand.class)).forEach(jRuleWhen -> {
             JRuleCondition jRuleCondition = jRuleWhen.condition();
             addToContext(new JRuleItemReceivedCommandExecutionContext(jRule, logName, loggingTags, method,
-                    jRuleWhen.item(), Optional.of(jRuleCondition.lt()).filter(aDouble -> aDouble != Double.MIN_VALUE),
+                    jRuleWhen.item(), jRuleWhen.memberOf(),
+                    Optional.of(jRuleCondition.lt()).filter(aDouble -> aDouble != Double.MIN_VALUE),
                     Optional.of(jRuleCondition.lte()).filter(aDouble -> aDouble != Double.MIN_VALUE),
                     Optional.of(jRuleCondition.gt()).filter(aDouble -> aDouble != Double.MIN_VALUE),
                     Optional.of(jRuleCondition.gte()).filter(aDouble -> aDouble != Double.MIN_VALUE),
@@ -187,7 +190,8 @@ public class JRuleEngine implements PropertyChangeListener {
 
         Arrays.stream(method.getAnnotationsByType(JRuleWhenItemChange.class)).forEach(jRuleWhen -> {
             JRuleCondition jRuleCondition = jRuleWhen.condition();
-            addToContext(new JRuleItemChangeExecutionContext(jRule, logName, loggingTags, method, jRuleWhen.item(),
+            addToContext(new JRuleItemChangeExecutionContext(jRule, logName, loggingTags, method,
+                    jRuleWhen.item(), jRuleWhen.memberOf(),
                     Optional.of(jRuleCondition.lt()).filter(aDouble -> aDouble != Double.MIN_VALUE),
                     Optional.of(jRuleCondition.lte()).filter(aDouble -> aDouble != Double.MIN_VALUE),
                     Optional.of(jRuleCondition.gt()).filter(aDouble -> aDouble != Double.MIN_VALUE),
@@ -252,8 +256,23 @@ public class JRuleEngine implements PropertyChangeListener {
     }
 
     public void fire(AbstractEvent event) {
-        contextList.stream().filter(context -> context.match(event)).filter(this::matchPrecondition)
+        JRuleItemExecutionContext.JRuleAdditionalItemCheckData additionalCheckData = getAdditionalCheckData(event);
+
+        contextList.stream().filter(context -> context.match(event, additionalCheckData)).filter(this::matchPrecondition)
                 .forEach(context -> invokeRule(context, context.createJRuleEvent(event)));
+    }
+
+    private JRuleItemExecutionContext.JRuleAdditionalItemCheckData getAdditionalCheckData(AbstractEvent event) {
+        return Optional.ofNullable(event instanceof ItemEvent ? ((ItemEvent) event).getItemName() : null)
+                .map(s -> {
+                    try {
+                        return itemRegistry.getItem(s);
+                    } catch (ItemNotFoundException e) {
+                        throw new IllegalStateException("this can never occur", e);
+                    }
+                })
+                .map(item -> new JRuleItemExecutionContext.JRuleAdditionalItemCheckData(item.getGroupNames()))
+                .orElse(new JRuleItemExecutionContext.JRuleAdditionalItemCheckData(List.of()));
     }
 
     private boolean matchPrecondition(JRuleExecutionContext jRuleExecutionContext) {
@@ -325,9 +344,21 @@ public class JRuleEngine implements PropertyChangeListener {
     }
 
     public boolean watchingForItem(String itemName) {
+        List<String> belongingGroups = Optional.of(itemName)
+                .map(s -> {
+                    try {
+                        return itemRegistry.getItem(s);
+                    } catch (ItemNotFoundException e) {
+                        throw new IllegalStateException("this can never occur", e);
+                    }
+                })
+                .map(Item::getGroupNames)
+                .orElse(List.of());
+
         boolean b = this.contextList.stream().filter(context -> context instanceof JRuleItemExecutionContext)
                 .map(context -> ((JRuleItemExecutionContext) context))
-                .anyMatch(context -> context.getItemName().equals(itemName));
+                .anyMatch(context -> (context.getItemName().equals(itemName) && !context.isMemberOf())
+                || (belongingGroups.contains(context.getItemName()) && context.isMemberOf()));
         logDebug("watching for item: '{}'? -> {}", itemName, b);
         return b;
     }

--- a/src/main/java/org/openhab/automation/jrule/internal/engine/excutioncontext/JRuleChannelExecutionContext.java
+++ b/src/main/java/org/openhab/automation/jrule/internal/engine/excutioncontext/JRuleChannelExecutionContext.java
@@ -13,6 +13,7 @@
 package org.openhab.automation.jrule.internal.engine.excutioncontext;
 
 import java.lang.reflect.Method;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
@@ -57,5 +58,12 @@ public class JRuleChannelExecutionContext extends JRuleExecutionContext {
     public JRuleEvent createJRuleEvent(AbstractEvent event) {
         return new JRuleChannelEvent(((ChannelTriggeredEvent) event).getChannel().getAsString(),
                 ((ChannelTriggeredEvent) event).getEvent());
+    }
+
+    @Override
+    public String toString() {
+        return "JRuleChannelExecutionContext{" + "channel='" + channel + '\'' + ", event=" + event + ", logName='"
+                + logName + '\'' + ", jRule=" + jRule + ", method=" + method + ", loggingTags="
+                + Arrays.toString(loggingTags) + ", preconditionContextList=" + preconditionContextList + '}';
     }
 }

--- a/src/main/java/org/openhab/automation/jrule/internal/engine/excutioncontext/JRuleChannelExecutionContext.java
+++ b/src/main/java/org/openhab/automation/jrule/internal/engine/excutioncontext/JRuleChannelExecutionContext.java
@@ -47,7 +47,7 @@ public class JRuleChannelExecutionContext extends JRuleExecutionContext {
     }
 
     @Override
-    public boolean match(AbstractEvent event) {
+    public boolean match(AbstractEvent event, JRuleAdditionalCheckData checkData) {
         return event instanceof ChannelTriggeredEvent
                 && ((ChannelTriggeredEvent) event).getChannel().getAsString().equals(this.channel)
                 && this.event.map(e -> e.equals(((ChannelTriggeredEvent) event).getEvent())).orElse(true);

--- a/src/main/java/org/openhab/automation/jrule/internal/engine/excutioncontext/JRuleExecutionContext.java
+++ b/src/main/java/org/openhab/automation/jrule/internal/engine/excutioncontext/JRuleExecutionContext.java
@@ -62,11 +62,15 @@ public abstract class JRuleExecutionContext {
         return loggingTags;
     }
 
-    public abstract boolean match(AbstractEvent event);
+    public abstract boolean match(AbstractEvent event, JRuleAdditionalCheckData checkData);
 
     public abstract JRuleEvent createJRuleEvent(AbstractEvent event);
 
     public List<JRulePreconditionContext> getPreconditionContextList() {
         return preconditionContextList;
+    }
+
+    public static class JRuleAdditionalCheckData {
+
     }
 }

--- a/src/main/java/org/openhab/automation/jrule/internal/engine/excutioncontext/JRuleExecutionContext.java
+++ b/src/main/java/org/openhab/automation/jrule/internal/engine/excutioncontext/JRuleExecutionContext.java
@@ -26,11 +26,11 @@ import org.openhab.core.events.AbstractEvent;
  * @author Joseph (Seaside) Hagberg - Initial contribution
  */
 public abstract class JRuleExecutionContext {
-    private final String logName;
+    protected final String logName;
     protected final JRule jRule;
     protected final Method method;
-    private final String[] loggingTags;
-    private final List<JRulePreconditionContext> preconditionContextList;
+    protected final String[] loggingTags;
+    protected final List<JRulePreconditionContext> preconditionContextList;
 
     public JRuleExecutionContext(JRule jRule, String logName, String[] loggingTags, Method method,
             List<JRulePreconditionContext> preconditionContextList) {
@@ -68,6 +68,13 @@ public abstract class JRuleExecutionContext {
 
     public List<JRulePreconditionContext> getPreconditionContextList() {
         return preconditionContextList;
+    }
+
+    @Override
+    public String toString() {
+        return "JRuleExecutionContext{" + "logName='" + logName + '\'' + ", jRule=" + jRule + ", method=" + method
+                + ", loggingTags=" + Arrays.toString(loggingTags) + ", preconditionContextList="
+                + preconditionContextList + '}';
     }
 
     public static class JRuleAdditionalCheckData {

--- a/src/main/java/org/openhab/automation/jrule/internal/engine/excutioncontext/JRuleItemChangeExecutionContext.java
+++ b/src/main/java/org/openhab/automation/jrule/internal/engine/excutioncontext/JRuleItemChangeExecutionContext.java
@@ -1,13 +1,13 @@
 /**
  * Copyright (c) 2010-2022 Contributors to the openHAB project
- * <p>
+ *
  * See the NOTICE file(s) distributed with this work for additional
  * information.
- * <p>
+ *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0
- * <p>
+ *
  * SPDX-License-Identifier: EPL-2.0
  */
 package org.openhab.automation.jrule.internal.engine.excutioncontext;
@@ -16,6 +16,7 @@ import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Optional;
 
+import org.openhab.automation.jrule.internal.JRuleLog;
 import org.openhab.automation.jrule.rules.JRule;
 import org.openhab.automation.jrule.rules.JRuleEventState;
 import org.openhab.automation.jrule.rules.event.JRuleEvent;
@@ -24,6 +25,8 @@ import org.openhab.core.events.AbstractEvent;
 import org.openhab.core.items.events.GroupItemStateChangedEvent;
 import org.openhab.core.items.events.ItemEvent;
 import org.openhab.core.items.events.ItemStateChangedEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The {@link JRuleItemChangeExecutionContext}
@@ -31,6 +34,7 @@ import org.openhab.core.items.events.ItemStateChangedEvent;
  * @author Robert Delbrück - Initial contribution
  */
 public class JRuleItemChangeExecutionContext extends JRuleItemExecutionContext {
+    private final Logger log = LoggerFactory.getLogger(JRuleItemChangeExecutionContext.class);
     private final Optional<String> from;
     private final Optional<String> to;
 
@@ -46,20 +50,21 @@ public class JRuleItemChangeExecutionContext extends JRuleItemExecutionContext {
 
     @Override
     public boolean match(AbstractEvent event, JRuleAdditionalCheckData checkData) {
+        JRuleLog.debug(log, "JRuleItemChangeExecutionContext", "does it match?: {}, {}, {}", this, event, checkData);
         if (!(event instanceof ItemStateChangedEvent
                 && super.matchCondition(((ItemStateChangedEvent) event).getItemState().toString())
                 && from.map(s -> ((ItemStateChangedEvent) event).getOldItemState().toString().equals(s)).orElse(true)
                 && to.map(s -> ((ItemStateChangedEvent) event).getItemState().toString().equals(s)).orElse(true))) {
             return false;
         }
-        if (!(!isMemberOf() && ((ItemStateChangedEvent) event).getItemName().equals(this.getItemName()))) {
-            return false;
+        if (!isMemberOf() && ((ItemStateChangedEvent) event).getItemName().equals(this.getItemName())) {
+            return true;
         }
-        if (!(isMemberOf() && checkData instanceof JRuleAdditionalItemCheckData
-                && ((JRuleAdditionalItemCheckData) checkData).getBelongingGroups().contains(this.getItemName()))) {
-            return false;
+        if (isMemberOf() && checkData instanceof JRuleAdditionalItemCheckData
+                && ((JRuleAdditionalItemCheckData) checkData).getBelongingGroups().contains(this.getItemName())) {
+            return true;
         }
-        return true;
+        return false;
     }
 
     @Override

--- a/src/main/java/org/openhab/automation/jrule/internal/engine/excutioncontext/JRuleItemChangeExecutionContext.java
+++ b/src/main/java/org/openhab/automation/jrule/internal/engine/excutioncontext/JRuleItemChangeExecutionContext.java
@@ -13,6 +13,7 @@
 package org.openhab.automation.jrule.internal.engine.excutioncontext;
 
 import java.lang.reflect.Method;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
@@ -81,5 +82,14 @@ public class JRuleItemChangeExecutionContext extends JRuleItemExecutionContext {
         return new JRuleItemEvent(this.getItemName(), memberName,
                 new JRuleEventState(((ItemStateChangedEvent) event).getItemState().toString()),
                 new JRuleEventState(((ItemStateChangedEvent) event).getOldItemState().toString()));
+    }
+
+    @Override
+    public String toString() {
+        return "JRuleItemChangeExecutionContext{" + "from=" + from + ", to=" + to + ", itemName='" + itemName + '\''
+                + ", memberOf=" + memberOf + ", gt=" + gt + ", gte=" + gte + ", lt=" + lt + ", lte=" + lte + ", eq="
+                + eq + ", neq=" + neq + ", logName='" + logName + '\'' + ", jRule=" + jRule + ", method=" + method
+                + ", loggingTags=" + Arrays.toString(loggingTags) + ", preconditionContextList="
+                + preconditionContextList + '}';
     }
 }

--- a/src/main/java/org/openhab/automation/jrule/internal/engine/excutioncontext/JRuleItemChangeExecutionContext.java
+++ b/src/main/java/org/openhab/automation/jrule/internal/engine/excutioncontext/JRuleItemChangeExecutionContext.java
@@ -1,13 +1,13 @@
 /**
  * Copyright (c) 2010-2022 Contributors to the openHAB project
- *
+ * <p>
  * See the NOTICE file(s) distributed with this work for additional
  * information.
- *
+ * <p>
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0
- *
+ * <p>
  * SPDX-License-Identifier: EPL-2.0
  */
 package org.openhab.automation.jrule.internal.engine.excutioncontext;
@@ -22,6 +22,7 @@ import org.openhab.automation.jrule.rules.event.JRuleEvent;
 import org.openhab.automation.jrule.rules.event.JRuleItemEvent;
 import org.openhab.core.events.AbstractEvent;
 import org.openhab.core.items.events.GroupItemStateChangedEvent;
+import org.openhab.core.items.events.ItemEvent;
 import org.openhab.core.items.events.ItemStateChangedEvent;
 
 /**
@@ -34,28 +35,45 @@ public class JRuleItemChangeExecutionContext extends JRuleItemExecutionContext {
     private final Optional<String> to;
 
     public JRuleItemChangeExecutionContext(JRule jRule, String logName, String[] loggingTags, Method method,
-            String itemName, Optional<Double> lt, Optional<Double> lte, Optional<Double> gt, Optional<Double> gte,
-            Optional<String> eq, Optional<String> neq, List<JRulePreconditionContext> preconditionContextList,
-            Optional<String> from, Optional<String> to) {
-        super(jRule, logName, loggingTags, method, itemName, lt, lte, gt, gte, eq, neq, preconditionContextList);
+                                           String itemName, boolean memberOf, Optional<Double> lt, Optional<Double> lte, Optional<Double> gt, Optional<Double> gte,
+                                           Optional<String> eq, Optional<String> neq, List<JRulePreconditionContext> preconditionContextList,
+                                           Optional<String> from, Optional<String> to) {
+        super(jRule, logName, loggingTags, method, itemName, memberOf, lt, lte, gt, gte, eq, neq, preconditionContextList);
         this.from = from;
         this.to = to;
     }
 
     @Override
-    public boolean match(AbstractEvent event) {
-        return event instanceof ItemStateChangedEvent
-                && ((ItemStateChangedEvent) event).getItemName().equals(this.getItemName())
+    public boolean match(AbstractEvent event, JRuleAdditionalCheckData checkData) {
+        if (!(event instanceof ItemStateChangedEvent
+                && super.matchCondition(((ItemStateChangedEvent) event).getItemState().toString())
                 && from.map(s -> ((ItemStateChangedEvent) event).getOldItemState().toString().equals(s)).orElse(true)
-                && to.map(s -> ((ItemStateChangedEvent) event).getItemState().toString().equals(s)).orElse(true)
-                && super.matchCondition(((ItemStateChangedEvent) event).getItemState().toString());
+                && to.map(s -> ((ItemStateChangedEvent) event).getItemState().toString().equals(s)).orElse(true))) {
+            return false;
+        }
+        if (!(!isMemberOf()
+                && ((ItemStateChangedEvent) event).getItemName().equals(this.getItemName()))) {
+            return false;
+        }
+        if (!(isMemberOf()
+                && checkData instanceof JRuleAdditionalItemCheckData
+                && ((JRuleAdditionalItemCheckData) checkData).getBelongingGroups().contains(this.getItemName()))) {
+            return false;
+        }
+        return true;
     }
 
     @Override
     public JRuleEvent createJRuleEvent(AbstractEvent event) {
-        String memberName = event instanceof GroupItemStateChangedEvent
-                ? ((GroupItemStateChangedEvent) event).getMemberName()
-                : null;
+        final String memberName;
+        if (isMemberOf()) {
+            memberName = ((ItemEvent) event).getItemName();
+        } else {
+            memberName = event instanceof GroupItemStateChangedEvent
+                    ? ((GroupItemStateChangedEvent) event).getMemberName()
+                    : null;
+        }
+
         return new JRuleItemEvent(this.getItemName(), memberName,
                 new JRuleEventState(((ItemStateChangedEvent) event).getItemState().toString()),
                 new JRuleEventState(((ItemStateChangedEvent) event).getOldItemState().toString()));

--- a/src/main/java/org/openhab/automation/jrule/internal/engine/excutioncontext/JRuleItemChangeExecutionContext.java
+++ b/src/main/java/org/openhab/automation/jrule/internal/engine/excutioncontext/JRuleItemChangeExecutionContext.java
@@ -35,10 +35,11 @@ public class JRuleItemChangeExecutionContext extends JRuleItemExecutionContext {
     private final Optional<String> to;
 
     public JRuleItemChangeExecutionContext(JRule jRule, String logName, String[] loggingTags, Method method,
-                                           String itemName, boolean memberOf, Optional<Double> lt, Optional<Double> lte, Optional<Double> gt, Optional<Double> gte,
-                                           Optional<String> eq, Optional<String> neq, List<JRulePreconditionContext> preconditionContextList,
-                                           Optional<String> from, Optional<String> to) {
-        super(jRule, logName, loggingTags, method, itemName, memberOf, lt, lte, gt, gte, eq, neq, preconditionContextList);
+            String itemName, boolean memberOf, Optional<Double> lt, Optional<Double> lte, Optional<Double> gt,
+            Optional<Double> gte, Optional<String> eq, Optional<String> neq,
+            List<JRulePreconditionContext> preconditionContextList, Optional<String> from, Optional<String> to) {
+        super(jRule, logName, loggingTags, method, itemName, memberOf, lt, lte, gt, gte, eq, neq,
+                preconditionContextList);
         this.from = from;
         this.to = to;
     }
@@ -51,12 +52,10 @@ public class JRuleItemChangeExecutionContext extends JRuleItemExecutionContext {
                 && to.map(s -> ((ItemStateChangedEvent) event).getItemState().toString().equals(s)).orElse(true))) {
             return false;
         }
-        if (!(!isMemberOf()
-                && ((ItemStateChangedEvent) event).getItemName().equals(this.getItemName()))) {
+        if (!(!isMemberOf() && ((ItemStateChangedEvent) event).getItemName().equals(this.getItemName()))) {
             return false;
         }
-        if (!(isMemberOf()
-                && checkData instanceof JRuleAdditionalItemCheckData
+        if (!(isMemberOf() && checkData instanceof JRuleAdditionalItemCheckData
                 && ((JRuleAdditionalItemCheckData) checkData).getBelongingGroups().contains(this.getItemName()))) {
             return false;
         }

--- a/src/main/java/org/openhab/automation/jrule/internal/engine/excutioncontext/JRuleItemExecutionContext.java
+++ b/src/main/java/org/openhab/automation/jrule/internal/engine/excutioncontext/JRuleItemExecutionContext.java
@@ -26,6 +26,7 @@ import org.openhab.core.library.types.QuantityType;
  */
 public abstract class JRuleItemExecutionContext extends JRuleExecutionContext {
     private final String itemName;
+    private final boolean memberOf;
     private final Optional<Double> gt;
     private final Optional<Double> gte;
     private final Optional<Double> lt;
@@ -34,10 +35,11 @@ public abstract class JRuleItemExecutionContext extends JRuleExecutionContext {
     protected final Optional<String> neq;
 
     public JRuleItemExecutionContext(JRule jRule, String logName, String[] loggingTags, Method method, String itemName,
-            Optional<Double> lt, Optional<Double> lte, Optional<Double> gt, Optional<Double> gte, Optional<String> eq,
-            Optional<String> neq, List<JRulePreconditionContext> preconditionContextList) {
+                                     boolean memberOf, Optional<Double> lt, Optional<Double> lte, Optional<Double> gt, Optional<Double> gte, Optional<String> eq,
+                                     Optional<String> neq, List<JRulePreconditionContext> preconditionContextList) {
         super(jRule, logName, loggingTags, method, preconditionContextList);
         this.itemName = itemName;
+        this.memberOf = memberOf;
         this.gt = gt;
         this.gte = gte;
         this.lt = lt;
@@ -96,5 +98,21 @@ public abstract class JRuleItemExecutionContext extends JRuleExecutionContext {
 
     public Optional<String> getNeq() {
         return neq;
+    }
+
+    public boolean isMemberOf() {
+        return memberOf;
+    }
+
+    public static class JRuleAdditionalItemCheckData extends JRuleAdditionalCheckData {
+        private final List<String> belongingGroups;
+
+        public JRuleAdditionalItemCheckData(List<String> belongingGroups) {
+            this.belongingGroups = belongingGroups;
+        }
+
+        public List<String> getBelongingGroups() {
+            return belongingGroups;
+        }
     }
 }

--- a/src/main/java/org/openhab/automation/jrule/internal/engine/excutioncontext/JRuleItemExecutionContext.java
+++ b/src/main/java/org/openhab/automation/jrule/internal/engine/excutioncontext/JRuleItemExecutionContext.java
@@ -13,7 +13,6 @@
 package org.openhab.automation.jrule.internal.engine.excutioncontext;
 
 import java.lang.reflect.Method;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
@@ -103,14 +102,6 @@ public abstract class JRuleItemExecutionContext extends JRuleExecutionContext {
 
     public boolean isMemberOf() {
         return memberOf;
-    }
-
-    @Override
-    public String toString() {
-        return "JRuleItemExecutionContext{" + "itemName='" + itemName + '\'' + ", memberOf=" + memberOf + ", gt=" + gt
-                + ", gte=" + gte + ", lt=" + lt + ", lte=" + lte + ", eq=" + eq + ", neq=" + neq + ", logName='"
-                + logName + '\'' + ", jRule=" + jRule + ", method=" + method + ", loggingTags="
-                + Arrays.toString(loggingTags) + ", preconditionContextList=" + preconditionContextList + '}';
     }
 
     public static class JRuleAdditionalItemCheckData extends JRuleAdditionalCheckData {

--- a/src/main/java/org/openhab/automation/jrule/internal/engine/excutioncontext/JRuleItemExecutionContext.java
+++ b/src/main/java/org/openhab/automation/jrule/internal/engine/excutioncontext/JRuleItemExecutionContext.java
@@ -35,8 +35,8 @@ public abstract class JRuleItemExecutionContext extends JRuleExecutionContext {
     protected final Optional<String> neq;
 
     public JRuleItemExecutionContext(JRule jRule, String logName, String[] loggingTags, Method method, String itemName,
-                                     boolean memberOf, Optional<Double> lt, Optional<Double> lte, Optional<Double> gt, Optional<Double> gte, Optional<String> eq,
-                                     Optional<String> neq, List<JRulePreconditionContext> preconditionContextList) {
+            boolean memberOf, Optional<Double> lt, Optional<Double> lte, Optional<Double> gt, Optional<Double> gte,
+            Optional<String> eq, Optional<String> neq, List<JRulePreconditionContext> preconditionContextList) {
         super(jRule, logName, loggingTags, method, preconditionContextList);
         this.itemName = itemName;
         this.memberOf = memberOf;

--- a/src/main/java/org/openhab/automation/jrule/internal/engine/excutioncontext/JRuleItemExecutionContext.java
+++ b/src/main/java/org/openhab/automation/jrule/internal/engine/excutioncontext/JRuleItemExecutionContext.java
@@ -13,6 +13,7 @@
 package org.openhab.automation.jrule.internal.engine.excutioncontext;
 
 import java.lang.reflect.Method;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
@@ -25,12 +26,12 @@ import org.openhab.core.library.types.QuantityType;
  * @author Robert Delbrück - Initial contribution
  */
 public abstract class JRuleItemExecutionContext extends JRuleExecutionContext {
-    private final String itemName;
-    private final boolean memberOf;
-    private final Optional<Double> gt;
-    private final Optional<Double> gte;
-    private final Optional<Double> lt;
-    private final Optional<Double> lte;
+    protected final String itemName;
+    protected final boolean memberOf;
+    protected final Optional<Double> gt;
+    protected final Optional<Double> gte;
+    protected final Optional<Double> lt;
+    protected final Optional<Double> lte;
     protected final Optional<String> eq;
     protected final Optional<String> neq;
 
@@ -104,6 +105,14 @@ public abstract class JRuleItemExecutionContext extends JRuleExecutionContext {
         return memberOf;
     }
 
+    @Override
+    public String toString() {
+        return "JRuleItemExecutionContext{" + "itemName='" + itemName + '\'' + ", memberOf=" + memberOf + ", gt=" + gt
+                + ", gte=" + gte + ", lt=" + lt + ", lte=" + lte + ", eq=" + eq + ", neq=" + neq + ", logName='"
+                + logName + '\'' + ", jRule=" + jRule + ", method=" + method + ", loggingTags="
+                + Arrays.toString(loggingTags) + ", preconditionContextList=" + preconditionContextList + '}';
+    }
+
     public static class JRuleAdditionalItemCheckData extends JRuleAdditionalCheckData {
         private final List<String> belongingGroups;
 
@@ -113,6 +122,11 @@ public abstract class JRuleItemExecutionContext extends JRuleExecutionContext {
 
         public List<String> getBelongingGroups() {
             return belongingGroups;
+        }
+
+        @Override
+        public String toString() {
+            return "JRuleAdditionalItemCheckData{" + "belongingGroups=" + belongingGroups + '}';
         }
     }
 }

--- a/src/main/java/org/openhab/automation/jrule/internal/engine/excutioncontext/JRuleItemReceivedCommandExecutionContext.java
+++ b/src/main/java/org/openhab/automation/jrule/internal/engine/excutioncontext/JRuleItemReceivedCommandExecutionContext.java
@@ -33,10 +33,11 @@ public class JRuleItemReceivedCommandExecutionContext extends JRuleItemExecution
     private final Optional<String> command;
 
     public JRuleItemReceivedCommandExecutionContext(JRule jRule, String logName, String[] loggingTags, Method method,
-                                                    String itemName, boolean memberOf, Optional<Double> lt, Optional<Double> lte, Optional<Double> gt, Optional<Double> gte,
-                                                    Optional<String> eq, Optional<String> neq, List<JRulePreconditionContext> preconditionContextList,
-                                                    Optional<String> command) {
-        super(jRule, logName, loggingTags, method, itemName, memberOf, lt, lte, gt, gte, eq, neq, preconditionContextList);
+            String itemName, boolean memberOf, Optional<Double> lt, Optional<Double> lte, Optional<Double> gt,
+            Optional<Double> gte, Optional<String> eq, Optional<String> neq,
+            List<JRulePreconditionContext> preconditionContextList, Optional<String> command) {
+        super(jRule, logName, loggingTags, method, itemName, memberOf, lt, lte, gt, gte, eq, neq,
+                preconditionContextList);
         this.command = command;
     }
 
@@ -47,12 +48,10 @@ public class JRuleItemReceivedCommandExecutionContext extends JRuleItemExecution
                 && command.map(s -> ((ItemCommandEvent) event).getItemCommand().toString().equals(s)).orElse(true))) {
             return false;
         }
-        if (!(!isMemberOf()
-                && ((ItemCommandEvent) event).getItemName().equals(this.getItemName()))) {
+        if (!(!isMemberOf() && ((ItemCommandEvent) event).getItemName().equals(this.getItemName()))) {
             return false;
         }
-        if (!(isMemberOf()
-                && checkData instanceof JRuleAdditionalItemCheckData
+        if (!(isMemberOf() && checkData instanceof JRuleAdditionalItemCheckData
                 && ((JRuleAdditionalItemCheckData) checkData).getBelongingGroups().contains(this.getItemName()))) {
             return false;
         }

--- a/src/main/java/org/openhab/automation/jrule/internal/engine/excutioncontext/JRuleItemReceivedCommandExecutionContext.java
+++ b/src/main/java/org/openhab/automation/jrule/internal/engine/excutioncontext/JRuleItemReceivedCommandExecutionContext.java
@@ -1,21 +1,23 @@
 /**
  * Copyright (c) 2010-2022 Contributors to the openHAB project
- * <p>
+ *
  * See the NOTICE file(s) distributed with this work for additional
  * information.
- * <p>
+ *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0
- * <p>
+ *
  * SPDX-License-Identifier: EPL-2.0
  */
 package org.openhab.automation.jrule.internal.engine.excutioncontext;
 
 import java.lang.reflect.Method;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
+import org.openhab.automation.jrule.internal.JRuleLog;
 import org.openhab.automation.jrule.rules.JRule;
 import org.openhab.automation.jrule.rules.JRuleEventState;
 import org.openhab.automation.jrule.rules.event.JRuleEvent;
@@ -23,6 +25,8 @@ import org.openhab.automation.jrule.rules.event.JRuleItemEvent;
 import org.openhab.core.events.AbstractEvent;
 import org.openhab.core.items.events.ItemCommandEvent;
 import org.openhab.core.items.events.ItemEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The {@link JRuleItemReceivedCommandExecutionContext}
@@ -30,7 +34,8 @@ import org.openhab.core.items.events.ItemEvent;
  * @author Robert Delbrück - Initial contribution
  */
 public class JRuleItemReceivedCommandExecutionContext extends JRuleItemExecutionContext {
-    private final Optional<String> command;
+    private static final Logger log = LoggerFactory.getLogger(JRuleItemReceivedCommandExecutionContext.class);
+    protected final Optional<String> command;
 
     public JRuleItemReceivedCommandExecutionContext(JRule jRule, String logName, String[] loggingTags, Method method,
             String itemName, boolean memberOf, Optional<Double> lt, Optional<Double> lte, Optional<Double> gt,
@@ -43,19 +48,22 @@ public class JRuleItemReceivedCommandExecutionContext extends JRuleItemExecution
 
     @Override
     public boolean match(AbstractEvent event, JRuleAdditionalCheckData checkData) {
+        JRuleLog.debug(log, "JRuleItemReceivedCommandExecutionContext", "does it match?: {}, {}, {}", this, event,
+                checkData);
         if (!(event instanceof ItemCommandEvent
                 && super.matchCondition(((ItemCommandEvent) event).getItemCommand().toString())
                 && command.map(s -> ((ItemCommandEvent) event).getItemCommand().toString().equals(s)).orElse(true))) {
             return false;
         }
-        if (!(!isMemberOf() && ((ItemCommandEvent) event).getItemName().equals(this.getItemName()))) {
-            return false;
+
+        if (!isMemberOf() && ((ItemCommandEvent) event).getItemName().equals(this.getItemName())) {
+            return true;
         }
-        if (!(isMemberOf() && checkData instanceof JRuleAdditionalItemCheckData
-                && ((JRuleAdditionalItemCheckData) checkData).getBelongingGroups().contains(this.getItemName()))) {
-            return false;
+        if (isMemberOf() && checkData instanceof JRuleAdditionalItemCheckData
+                && ((JRuleAdditionalItemCheckData) checkData).getBelongingGroups().contains(this.getItemName())) {
+            return true;
         }
-        return true;
+        return false;
     }
 
     @Override
@@ -69,5 +77,14 @@ public class JRuleItemReceivedCommandExecutionContext extends JRuleItemExecution
 
         return new JRuleItemEvent(this.getItemName(), memberName,
                 new JRuleEventState(((ItemCommandEvent) event).getItemCommand().toString()), null);
+    }
+
+    @Override
+    public String toString() {
+        return "JRuleItemReceivedCommandExecutionContext{" + "command=" + command + ", itemName='" + itemName + '\''
+                + ", memberOf=" + memberOf + ", gt=" + gt + ", gte=" + gte + ", lt=" + lt + ", lte=" + lte + ", eq="
+                + eq + ", neq=" + neq + ", logName='" + logName + '\'' + ", jRule=" + jRule + ", method=" + method
+                + ", loggingTags=" + Arrays.toString(loggingTags) + ", preconditionContextList="
+                + preconditionContextList + '}';
     }
 }

--- a/src/main/java/org/openhab/automation/jrule/internal/engine/excutioncontext/JRuleItemReceivedCommandExecutionContext.java
+++ b/src/main/java/org/openhab/automation/jrule/internal/engine/excutioncontext/JRuleItemReceivedCommandExecutionContext.java
@@ -1,13 +1,13 @@
 /**
  * Copyright (c) 2010-2022 Contributors to the openHAB project
- *
+ * <p>
  * See the NOTICE file(s) distributed with this work for additional
  * information.
- *
+ * <p>
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0
- *
+ * <p>
  * SPDX-License-Identifier: EPL-2.0
  */
 package org.openhab.automation.jrule.internal.engine.excutioncontext;
@@ -22,6 +22,7 @@ import org.openhab.automation.jrule.rules.event.JRuleEvent;
 import org.openhab.automation.jrule.rules.event.JRuleItemEvent;
 import org.openhab.core.events.AbstractEvent;
 import org.openhab.core.items.events.ItemCommandEvent;
+import org.openhab.core.items.events.ItemEvent;
 
 /**
  * The {@link JRuleItemReceivedCommandExecutionContext}
@@ -32,23 +33,42 @@ public class JRuleItemReceivedCommandExecutionContext extends JRuleItemExecution
     private final Optional<String> command;
 
     public JRuleItemReceivedCommandExecutionContext(JRule jRule, String logName, String[] loggingTags, Method method,
-            String itemName, Optional<Double> lt, Optional<Double> lte, Optional<Double> gt, Optional<Double> gte,
-            Optional<String> eq, Optional<String> neq, List<JRulePreconditionContext> preconditionContextList,
-            Optional<String> command) {
-        super(jRule, logName, loggingTags, method, itemName, lt, lte, gt, gte, eq, neq, preconditionContextList);
+                                                    String itemName, boolean memberOf, Optional<Double> lt, Optional<Double> lte, Optional<Double> gt, Optional<Double> gte,
+                                                    Optional<String> eq, Optional<String> neq, List<JRulePreconditionContext> preconditionContextList,
+                                                    Optional<String> command) {
+        super(jRule, logName, loggingTags, method, itemName, memberOf, lt, lte, gt, gte, eq, neq, preconditionContextList);
         this.command = command;
     }
 
     @Override
-    public boolean match(AbstractEvent event) {
-        return event instanceof ItemCommandEvent && ((ItemCommandEvent) event).getItemName().equals(this.getItemName())
-                && command.map(s -> ((ItemCommandEvent) event).getItemCommand().toString().equals(s)).orElse(true)
-                && super.matchCondition(((ItemCommandEvent) event).getItemCommand().toString());
+    public boolean match(AbstractEvent event, JRuleAdditionalCheckData checkData) {
+        if (!(event instanceof ItemCommandEvent
+                && super.matchCondition(((ItemCommandEvent) event).getItemCommand().toString())
+                && command.map(s -> ((ItemCommandEvent) event).getItemCommand().toString().equals(s)).orElse(true))) {
+            return false;
+        }
+        if (!(!isMemberOf()
+                && ((ItemCommandEvent) event).getItemName().equals(this.getItemName()))) {
+            return false;
+        }
+        if (!(isMemberOf()
+                && checkData instanceof JRuleAdditionalItemCheckData
+                && ((JRuleAdditionalItemCheckData) checkData).getBelongingGroups().contains(this.getItemName()))) {
+            return false;
+        }
+        return true;
     }
 
     @Override
     public JRuleEvent createJRuleEvent(AbstractEvent event) {
-        return new JRuleItemEvent(this.getItemName(), null,
+        final String memberName;
+        if (isMemberOf()) {
+            memberName = ((ItemEvent) event).getItemName();
+        } else {
+            memberName = null;
+        }
+
+        return new JRuleItemEvent(this.getItemName(), memberName,
                 new JRuleEventState(((ItemCommandEvent) event).getItemCommand().toString()), null);
     }
 }

--- a/src/main/java/org/openhab/automation/jrule/internal/engine/excutioncontext/JRuleItemReceivedUpdateExecutionContext.java
+++ b/src/main/java/org/openhab/automation/jrule/internal/engine/excutioncontext/JRuleItemReceivedUpdateExecutionContext.java
@@ -33,10 +33,11 @@ public class JRuleItemReceivedUpdateExecutionContext extends JRuleItemExecutionC
     private final Optional<String> state;
 
     public JRuleItemReceivedUpdateExecutionContext(JRule jRule, String logName, String[] loggingTags, Method method,
-                                                   String itemName, boolean memberOf, Optional<Double> lt, Optional<Double> lte, Optional<Double> gt, Optional<Double> gte,
-                                                   Optional<String> eq, Optional<String> neq, List<JRulePreconditionContext> preconditionContextList,
-                                                   Optional<String> state) {
-        super(jRule, logName, loggingTags, method, itemName, memberOf, lt, lte, gt, gte, eq, neq, preconditionContextList);
+            String itemName, boolean memberOf, Optional<Double> lt, Optional<Double> lte, Optional<Double> gt,
+            Optional<Double> gte, Optional<String> eq, Optional<String> neq,
+            List<JRulePreconditionContext> preconditionContextList, Optional<String> state) {
+        super(jRule, logName, loggingTags, method, itemName, memberOf, lt, lte, gt, gte, eq, neq,
+                preconditionContextList);
         this.state = state;
     }
 
@@ -47,12 +48,10 @@ public class JRuleItemReceivedUpdateExecutionContext extends JRuleItemExecutionC
                 && state.map(s -> ((ItemStateEvent) event).getItemState().toString().equals(s)).orElse(true))) {
             return false;
         }
-        if (!(!isMemberOf()
-                && ((ItemStateEvent) event).getItemName().equals(this.getItemName()))) {
+        if (!(!isMemberOf() && ((ItemStateEvent) event).getItemName().equals(this.getItemName()))) {
             return false;
         }
-        if (!(isMemberOf()
-                && checkData instanceof JRuleAdditionalItemCheckData
+        if (!(isMemberOf() && checkData instanceof JRuleAdditionalItemCheckData
                 && ((JRuleAdditionalItemCheckData) checkData).getBelongingGroups().contains(this.getItemName()))) {
             return false;
         }

--- a/src/main/java/org/openhab/automation/jrule/internal/engine/excutioncontext/JRulePreconditionContext.java
+++ b/src/main/java/org/openhab/automation/jrule/internal/engine/excutioncontext/JRulePreconditionContext.java
@@ -67,4 +67,10 @@ public class JRulePreconditionContext {
     public Optional<String> getNeq() {
         return neq;
     }
+
+    @Override
+    public String toString() {
+        return "JRulePreconditionContext{" + "item='" + item + '\'' + ", lt=" + lt + ", lte=" + lte + ", gt=" + gt
+                + ", gte=" + gte + ", eq=" + eq + ", neq=" + neq + '}';
+    }
 }

--- a/src/main/java/org/openhab/automation/jrule/internal/engine/excutioncontext/JRuleThingExecutionContext.java
+++ b/src/main/java/org/openhab/automation/jrule/internal/engine/excutioncontext/JRuleThingExecutionContext.java
@@ -53,7 +53,7 @@ public class JRuleThingExecutionContext extends JRuleExecutionContext {
     }
 
     @Override
-    public boolean match(AbstractEvent event) {
+    public boolean match(AbstractEvent event, JRuleAdditionalCheckData checkData) {
         if (!(event instanceof ThingStatusInfoChangedEvent)) {
             return false;
         }

--- a/src/main/java/org/openhab/automation/jrule/internal/engine/excutioncontext/JRuleThingExecutionContext.java
+++ b/src/main/java/org/openhab/automation/jrule/internal/engine/excutioncontext/JRuleThingExecutionContext.java
@@ -13,6 +13,7 @@
 package org.openhab.automation.jrule.internal.engine.excutioncontext;
 
 import java.lang.reflect.Method;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
@@ -47,12 +48,6 @@ public class JRuleThingExecutionContext extends JRuleExecutionContext {
     }
 
     @Override
-    public String toString() {
-        return "JRuleThingExecutionContext{" + "thing='" + thing + '\'' + ", from='" + from + '\'' + ", to='" + to
-                + '\'' + '}';
-    }
-
-    @Override
     public boolean match(AbstractEvent event, JRuleAdditionalCheckData checkData) {
         if (!(event instanceof ThingStatusInfoChangedEvent)) {
             return false;
@@ -67,5 +62,12 @@ public class JRuleThingExecutionContext extends JRuleExecutionContext {
     public JRuleEvent createJRuleEvent(AbstractEvent event) {
         return new JRuleThingEvent(((ThingStatusInfoChangedEvent) event).getThingUID().toString(),
                 ((ThingStatusInfoChangedEvent) event).getStatusInfo().getStatus().name());
+    }
+
+    @Override
+    public String toString() {
+        return "JRuleThingExecutionContext{" + "thing=" + thing + ", from=" + from + ", to=" + to + ", logName='"
+                + logName + '\'' + ", jRule=" + jRule + ", method=" + method + ", loggingTags="
+                + Arrays.toString(loggingTags) + ", preconditionContextList=" + preconditionContextList + '}';
     }
 }

--- a/src/main/java/org/openhab/automation/jrule/internal/engine/excutioncontext/JRuleTimeTimerExecutionContext.java
+++ b/src/main/java/org/openhab/automation/jrule/internal/engine/excutioncontext/JRuleTimeTimerExecutionContext.java
@@ -13,6 +13,7 @@
 package org.openhab.automation.jrule.internal.engine.excutioncontext;
 
 import java.lang.reflect.Method;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
@@ -60,5 +61,12 @@ public class JRuleTimeTimerExecutionContext extends JRuleTimedExecutionContext {
 
     public Optional<Integer> getSecond() {
         return second;
+    }
+
+    @Override
+    public String toString() {
+        return "JRuleTimeTimerExecutionContext{" + "hour=" + hour + ", minute=" + minute + ", second=" + second
+                + ", logName='" + logName + '\'' + ", jRule=" + jRule + ", method=" + method + ", loggingTags="
+                + Arrays.toString(loggingTags) + ", preconditionContextList=" + preconditionContextList + '}';
     }
 }

--- a/src/main/java/org/openhab/automation/jrule/internal/engine/excutioncontext/JRuleTimeTimerExecutionContext.java
+++ b/src/main/java/org/openhab/automation/jrule/internal/engine/excutioncontext/JRuleTimeTimerExecutionContext.java
@@ -41,7 +41,7 @@ public class JRuleTimeTimerExecutionContext extends JRuleTimedExecutionContext {
     }
 
     @Override
-    public boolean match(AbstractEvent event) {
+    public boolean match(AbstractEvent event, JRuleAdditionalCheckData checkData) {
         return false;
     }
 

--- a/src/main/java/org/openhab/automation/jrule/internal/engine/excutioncontext/JRuleTimedCronExecutionContext.java
+++ b/src/main/java/org/openhab/automation/jrule/internal/engine/excutioncontext/JRuleTimedCronExecutionContext.java
@@ -35,7 +35,7 @@ public class JRuleTimedCronExecutionContext extends JRuleTimedExecutionContext {
     }
 
     @Override
-    public boolean match(AbstractEvent event) {
+    public boolean match(AbstractEvent event, JRuleAdditionalCheckData checkData) {
         return false;
     }
 

--- a/src/main/java/org/openhab/automation/jrule/internal/engine/excutioncontext/JRuleTimedCronExecutionContext.java
+++ b/src/main/java/org/openhab/automation/jrule/internal/engine/excutioncontext/JRuleTimedCronExecutionContext.java
@@ -13,6 +13,7 @@
 package org.openhab.automation.jrule.internal.engine.excutioncontext;
 
 import java.lang.reflect.Method;
+import java.util.Arrays;
 import java.util.List;
 
 import org.openhab.automation.jrule.rules.JRule;
@@ -46,5 +47,12 @@ public class JRuleTimedCronExecutionContext extends JRuleTimedExecutionContext {
 
     public String getCron() {
         return cron;
+    }
+
+    @Override
+    public String toString() {
+        return "JRuleTimedCronExecutionContext{" + "cron='" + cron + '\'' + ", logName='" + logName + '\'' + ", jRule="
+                + jRule + ", method=" + method + ", loggingTags=" + Arrays.toString(loggingTags)
+                + ", preconditionContextList=" + preconditionContextList + '}';
     }
 }

--- a/src/main/java/org/openhab/automation/jrule/rules/JRuleWhenItemChange.java
+++ b/src/main/java/org/openhab/automation/jrule/rules/JRuleWhenItemChange.java
@@ -33,5 +33,7 @@ public @interface JRuleWhenItemChange {
 
     String to() default "";
 
+    boolean memberOf() default false;
+
     JRuleCondition condition() default @JRuleCondition;
 }

--- a/src/main/java/org/openhab/automation/jrule/rules/JRuleWhenItemReceivedCommand.java
+++ b/src/main/java/org/openhab/automation/jrule/rules/JRuleWhenItemReceivedCommand.java
@@ -31,5 +31,7 @@ public @interface JRuleWhenItemReceivedCommand {
 
     String command() default "";
 
+    boolean memberOf() default false;
+
     JRuleCondition condition() default @JRuleCondition;
 }

--- a/src/main/java/org/openhab/automation/jrule/rules/JRuleWhenItemReceivedUpdate.java
+++ b/src/main/java/org/openhab/automation/jrule/rules/JRuleWhenItemReceivedUpdate.java
@@ -31,5 +31,7 @@ public @interface JRuleWhenItemReceivedUpdate {
 
     String state() default "";
 
+    boolean memberOf() default false;
+
     JRuleCondition condition() default @JRuleCondition;
 }

--- a/src/test/java/org/openhab/binding/jrule/internal/triggers/JRuleAbstractTest.java
+++ b/src/test/java/org/openhab/binding/jrule/internal/triggers/JRuleAbstractTest.java
@@ -18,16 +18,12 @@ import java.util.Map;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.mockito.Mockito;
-import org.mockito.stubbing.Answer;
 import org.openhab.automation.jrule.internal.JRuleConfig;
 import org.openhab.automation.jrule.internal.engine.JRuleEngine;
 import org.openhab.automation.jrule.internal.test.JRuleMockedEventBus;
 import org.openhab.automation.jrule.rules.JRule;
 import org.openhab.core.events.Event;
-import org.openhab.core.items.Item;
-import org.openhab.core.items.ItemNotFoundException;
 import org.openhab.core.items.ItemRegistry;
-import org.openhab.core.library.items.StringItem;
 
 /**
  * The {@link JRuleAbstractTest} is a base class for simple rule trigger testing
@@ -36,6 +32,8 @@ import org.openhab.core.library.items.StringItem;
  * @author Arne Seime - Initial contribution
  */
 public abstract class JRuleAbstractTest {
+    protected static ItemRegistry itemRegistry = Mockito.mock(ItemRegistry.class);
+
     @BeforeAll
     public static void initEngine() {
         Map<String, Object> properties = new HashMap<>();
@@ -45,14 +43,6 @@ public abstract class JRuleAbstractTest {
 
         JRuleEngine engine = JRuleEngine.get();
         engine.setConfig(config);
-
-        ItemRegistry itemRegistry = Mockito.mock(ItemRegistry.class);
-        try {
-            Mockito.when(itemRegistry.getItem(Mockito.anyString()))
-                    .then((Answer<Item>) invocationOnMock -> new StringItem(invocationOnMock.getArgument(0)));
-        } catch (ItemNotFoundException e) {
-            throw new RuntimeException(e);
-        }
         engine.setItemRegistry(itemRegistry);
     }
 

--- a/src/test/java/org/openhab/binding/jrule/internal/triggers/JRuleAbstractTest.java
+++ b/src/test/java/org/openhab/binding/jrule/internal/triggers/JRuleAbstractTest.java
@@ -18,11 +18,16 @@ import java.util.Map;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.mockito.Mockito;
+import org.mockito.stubbing.Answer;
 import org.openhab.automation.jrule.internal.JRuleConfig;
 import org.openhab.automation.jrule.internal.engine.JRuleEngine;
 import org.openhab.automation.jrule.internal.test.JRuleMockedEventBus;
 import org.openhab.automation.jrule.rules.JRule;
 import org.openhab.core.events.Event;
+import org.openhab.core.items.Item;
+import org.openhab.core.items.ItemNotFoundException;
+import org.openhab.core.items.ItemRegistry;
+import org.openhab.core.library.items.StringItem;
 
 /**
  * The {@link JRuleAbstractTest} is a base class for simple rule trigger testing
@@ -40,6 +45,15 @@ public abstract class JRuleAbstractTest {
 
         JRuleEngine engine = JRuleEngine.get();
         engine.setConfig(config);
+
+        ItemRegistry itemRegistry = Mockito.mock(ItemRegistry.class);
+        try {
+            Mockito.when(itemRegistry.getItem(Mockito.anyString()))
+                    .then((Answer<Item>) invocationOnMock -> new StringItem(invocationOnMock.getArgument(0)));
+        } catch (ItemNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+        engine.setItemRegistry(itemRegistry);
     }
 
     protected <T extends JRule> T initRule(T rule) {

--- a/src/test/java/org/openhab/binding/jrule/internal/triggers/itemchange/JRuleGroupItemChangeRules.java
+++ b/src/test/java/org/openhab/binding/jrule/internal/triggers/itemchange/JRuleGroupItemChangeRules.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.jrule.internal.triggers.itemchange;
+
+import org.openhab.automation.jrule.rules.JRule;
+import org.openhab.automation.jrule.rules.JRuleName;
+import org.openhab.automation.jrule.rules.JRuleWhenItemChange;
+import org.openhab.automation.jrule.rules.event.JRuleEvent;
+
+/**
+ * The {@link JRuleGroupItemChangeRules} contains rules for testing @JRuleWhenItemChange with memberOf=true trigger
+ *
+ *
+ * @author Robert Delbrück - Initial contribution
+ */
+public class JRuleGroupItemChangeRules extends JRule {
+
+    public static final String GROUP_ITEM = "group_item";
+    public static final String GROUP_ITEM_FROM = "group_item_from";
+    public static final String GROUP_ITEM_TO = "group_item_to";
+    public static final String GROUP_ITEM_FROM_TO = "group_item_from_to";
+
+    @JRuleName("Test JRuleWhenGroupItemChange")
+    @JRuleWhenItemChange(item = GROUP_ITEM, memberOf = true)
+    public void groupItemChange(JRuleEvent event) {
+    }
+
+    @JRuleName("Test JRuleWhenGroupItemChange/from")
+    @JRuleWhenItemChange(item = GROUP_ITEM_FROM, from = "1", memberOf = true)
+    public void groupItemChangeFrom(JRuleEvent event) {
+    }
+
+    @JRuleName("Test JRuleWhenGroupItemChange/to")
+    @JRuleWhenItemChange(item = GROUP_ITEM_TO, to = "1", memberOf = true)
+    public void groupItemChangeTo(JRuleEvent event) {
+    }
+
+    @JRuleName("Test JRuleWhenGroupItemChange/from/to")
+    @JRuleWhenItemChange(item = GROUP_ITEM_FROM_TO, from = "1", to = "2", memberOf = true)
+    public void groupItemChangeFromTo(JRuleEvent event) {
+    }
+}

--- a/src/test/java/org/openhab/binding/jrule/internal/triggers/itemchange/JRuleGroupItemChangeTest.java
+++ b/src/test/java/org/openhab/binding/jrule/internal/triggers/itemchange/JRuleGroupItemChangeTest.java
@@ -1,0 +1,123 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.jrule.internal.triggers.itemchange;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.mockito.stubbing.Answer;
+import org.openhab.automation.jrule.rules.event.JRuleEvent;
+import org.openhab.binding.jrule.internal.triggers.JRuleAbstractTest;
+import org.openhab.core.events.Event;
+import org.openhab.core.items.Item;
+import org.openhab.core.items.ItemNotFoundException;
+import org.openhab.core.items.events.ItemEventFactory;
+import org.openhab.core.library.items.StringItem;
+import org.openhab.core.library.types.StringType;
+
+/**
+ * The {@link JRuleGroupItemChangeRules} contains tests for @JRuleWhenItemChange with memberOf=true trigger
+ *
+ *
+ * @author Robert Delbrück - Initial contribution
+ */
+public class JRuleGroupItemChangeTest extends JRuleAbstractTest {
+
+    public static final String MEMBER_ITEM = "memberof_item";
+    public static final String OTHER_ITEM = "other_item";
+
+    @BeforeAll
+    public static void initTestClass() throws ItemNotFoundException {
+        Mockito.when(itemRegistry.getItem(OTHER_ITEM))
+                .then((Answer<Item>) invocationOnMock -> new StringItem(invocationOnMock.getArgument(0)));
+    }
+
+    @Test
+    public void testItemChange_selfGroup() {
+        JRuleGroupItemChangeRules rule = initRule(new JRuleGroupItemChangeRules());
+        // Only last event should trigger rule method
+        fireEvents(List.of(itemChangeEvent(JRuleGroupItemChangeRules.GROUP_ITEM, "2", "1")));
+        verify(rule, times(0)).groupItemChange(Mockito.any(JRuleEvent.class));
+    }
+
+    @Test
+    public void testItemChange_no_from_to() throws ItemNotFoundException {
+        Mockito.when(itemRegistry.getItem(MEMBER_ITEM)).then((Answer<Item>) invocationOnMock -> {
+            StringItem stringItem = Mockito.mock(StringItem.class);
+            Mockito.when(stringItem.getName()).thenReturn(invocationOnMock.getArgument(0));
+            Mockito.when(stringItem.getGroupNames()).thenReturn(List.of(JRuleGroupItemChangeRules.GROUP_ITEM));
+            return stringItem;
+        });
+
+        JRuleGroupItemChangeRules rule = initRule(new JRuleGroupItemChangeRules());
+        // Only last event should trigger rule method
+        fireEvents(List.of(itemChangeEvent(OTHER_ITEM, "2", "1"), itemChangeEvent(MEMBER_ITEM, "2", "1")));
+        verify(rule, times(1)).groupItemChange(Mockito.any(JRuleEvent.class));
+    }
+
+    @Test
+    public void testItemChange_from() throws ItemNotFoundException {
+        Mockito.when(itemRegistry.getItem(MEMBER_ITEM)).then((Answer<Item>) invocationOnMock -> {
+            StringItem stringItem = Mockito.mock(StringItem.class);
+            Mockito.when(stringItem.getName()).thenReturn(invocationOnMock.getArgument(0));
+            Mockito.when(stringItem.getGroupNames()).thenReturn(List.of(JRuleGroupItemChangeRules.GROUP_ITEM_FROM));
+            return stringItem;
+        });
+
+        JRuleGroupItemChangeRules rule = initRule(new JRuleGroupItemChangeRules());
+        // Only last event should trigger rule method
+        fireEvents(List.of(itemChangeEvent(MEMBER_ITEM, "2", "1"), itemChangeEvent(MEMBER_ITEM, "1", "2")));
+        verify(rule, times(1)).groupItemChangeFrom(Mockito.any(JRuleEvent.class));
+    }
+
+    @Test
+    public void testItemChange_to() throws ItemNotFoundException {
+        Mockito.when(itemRegistry.getItem(MEMBER_ITEM)).then((Answer<Item>) invocationOnMock -> {
+            StringItem stringItem = Mockito.mock(StringItem.class);
+            Mockito.when(stringItem.getName()).thenReturn(invocationOnMock.getArgument(0));
+            Mockito.when(stringItem.getGroupNames()).thenReturn(List.of(JRuleGroupItemChangeRules.GROUP_ITEM_TO));
+            return stringItem;
+        });
+
+        JRuleGroupItemChangeRules rule = initRule(new JRuleGroupItemChangeRules());
+        // Only last event should trigger rule method
+        fireEvents(List.of(itemChangeEvent(MEMBER_ITEM, "1", "2"), itemChangeEvent(MEMBER_ITEM, "2", "1")));
+        verify(rule, times(1)).groupItemChangeTo(Mockito.any(JRuleEvent.class));
+    }
+
+    @Test
+    public void testItemChange_from_to() throws ItemNotFoundException {
+        Mockito.when(itemRegistry.getItem(MEMBER_ITEM)).then((Answer<Item>) invocationOnMock -> {
+            StringItem stringItem = Mockito.mock(StringItem.class);
+            Mockito.when(stringItem.getName()).thenReturn(invocationOnMock.getArgument(0));
+            Mockito.when(stringItem.getGroupNames()).thenReturn(List.of(JRuleGroupItemChangeRules.GROUP_ITEM_FROM_TO));
+            return stringItem;
+        });
+
+        JRuleGroupItemChangeRules rule = initRule(new JRuleGroupItemChangeRules());
+        // Only last event should trigger rule method
+        fireEvents(List.of(itemChangeEvent(MEMBER_ITEM, "2", "1"), itemChangeEvent(MEMBER_ITEM, "3", "2"),
+                itemChangeEvent(MEMBER_ITEM, "1", "2")));
+        verify(rule, times(1)).groupItemChangeFromTo(Mockito.any(JRuleEvent.class));
+    }
+
+    // Syntactic sugar
+    private Event itemChangeEvent(String item, String from, String to) {
+        return ItemEventFactory.createStateChangedEvent(item, new StringType(to), new StringType(from));
+    }
+}

--- a/src/test/java/org/openhab/binding/jrule/internal/triggers/itemchange/JRuleItemChangeTest.java
+++ b/src/test/java/org/openhab/binding/jrule/internal/triggers/itemchange/JRuleItemChangeTest.java
@@ -17,12 +17,17 @@ import static org.mockito.Mockito.verify;
 
 import java.util.List;
 
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+import org.mockito.stubbing.Answer;
 import org.openhab.automation.jrule.rules.event.JRuleEvent;
 import org.openhab.binding.jrule.internal.triggers.JRuleAbstractTest;
 import org.openhab.core.events.Event;
+import org.openhab.core.items.Item;
+import org.openhab.core.items.ItemNotFoundException;
 import org.openhab.core.items.events.ItemEventFactory;
+import org.openhab.core.library.items.StringItem;
 import org.openhab.core.library.types.StringType;
 
 /**
@@ -32,6 +37,11 @@ import org.openhab.core.library.types.StringType;
  * @author Arne Seime - Initial contribution
  */
 public class JRuleItemChangeTest extends JRuleAbstractTest {
+    @BeforeAll
+    public static void initTestClass() throws ItemNotFoundException {
+        Mockito.when(itemRegistry.getItem(Mockito.anyString()))
+                .then((Answer<Item>) invocationOnMock -> new StringItem(invocationOnMock.getArgument(0)));
+    }
 
     @Test
     public void testItemChange_no_from_to() {


### PR DESCRIPTION
Created a memberOf option for item event triggers.
Discussed here: https://github.com/seaside1/jrule/issues/22
When setting memberOf=true on a group-item the rule will fire for all direct group member events.