### PR TITLE
Initial tests for JRuleWhenItemChange triggers

### DIFF
--- a/src/main/java/org/openhab/automation/jrule/internal/test/JRuleMockedEventBus.java
+++ b/src/main/java/org/openhab/automation/jrule/internal/test/JRuleMockedEventBus.java
@@ -12,9 +12,11 @@
  */
 package org.openhab.automation.jrule.internal.test;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.openhab.automation.jrule.internal.events.JRuleEventSubscriber;
+import org.openhab.core.events.Event;
 
 /**
  * The {@link JRuleMockedEventBus}
@@ -23,7 +25,7 @@ import org.openhab.automation.jrule.internal.events.JRuleEventSubscriber;
  */
 public class JRuleMockedEventBus extends JRuleEventSubscriber {
 
-    private final List<JRuleMockedItemStateChangedEvent> eventList;
+    private final List<Event> eventList;
 
     public JRuleMockedEventBus(String eventBusResourceName) {
         super();
@@ -31,8 +33,14 @@ public class JRuleMockedEventBus extends JRuleEventSubscriber {
         eventList = parser.parse();
     }
 
+    public JRuleMockedEventBus(List<Event> events) {
+        eventList = new ArrayList<>();
+        eventList.addAll(events);
+    }
+
     public void start() {
         startSubscriber();
         eventList.forEach(super::receive);
+        stopSubscriber();
     }
 }

--- a/src/main/java/org/openhab/automation/jrule/internal/test/JRuleTestEventLogParser.java
+++ b/src/main/java/org/openhab/automation/jrule/internal/test/JRuleTestEventLogParser.java
@@ -22,6 +22,7 @@ import java.util.List;
 import org.openhab.automation.jrule.internal.JRuleLog;
 import org.openhab.automation.jrule.internal.JRuleUtil;
 import org.openhab.automation.jrule.internal.handler.JRuleHandler;
+import org.openhab.core.events.Event;
 import org.openhab.core.types.State;
 import org.openhab.core.types.Type;
 import org.openhab.core.types.TypeParser;
@@ -43,12 +44,14 @@ public class JRuleTestEventLogParser {
         url = getResourceUrl(eventLogResourceName);
     }
 
-    private List<JRuleMockedItemStateChangedEvent> readFromUrl(URL url) {
-        final List<JRuleMockedItemStateChangedEvent> changeEventList = new ArrayList<>();
+    private List<Event> readFromUrl(URL url) {
+        final List<Event> changeEventList = new ArrayList<>();
         try {
             final BufferedReader reader = new BufferedReader(new InputStreamReader(url.openStream()));
             while (reader.ready()) {
                 final String line = reader.readLine();
+
+                // TODO must parse all kinds of events
                 final JRuleMockedItemStateChangedEvent parseItemFromLine = parseItemFromLine(line);
                 if (parseItemFromLine != null) {
                     changeEventList.add(parseItemFromLine);
@@ -90,7 +93,7 @@ public class JRuleTestEventLogParser {
         return null;
     }
 
-    public List<JRuleMockedItemStateChangedEvent> parse() {
+    public List<Event> parse() {
         return readFromUrl(url);
     }
 

--- a/src/main/java/org/openhab/automation/jrule/rules/JRule.java
+++ b/src/main/java/org/openhab/automation/jrule/rules/JRule.java
@@ -111,11 +111,11 @@ public class JRule {
         CompletableFuture<Void> future = JRuleUtil.delayedExecution(timeInSeconds, TimeUnit.SECONDS);
         ruleNameToTimerFuture.put(ruleName, future);
         JRuleLog.info(logger, ruleName, "Start timer timeSeconds: {} hashCode: {}", timeInSeconds, future.hashCode());
-        return future.thenAccept(fn).thenAccept(s -> {
+        return future.thenAccept(s -> {
             JRuleLog.info(logger, ruleName, "Timer has finsihed");
             JRuleLog.debug(logger, ruleName, "Timer has finsihed hashCode: {}", future.hashCode());
             ruleNameToTimerFuture.remove(ruleName);
-        });
+        }).thenAccept(fn);
     }
 
     protected synchronized List<CompletableFuture<Void>> createOrReplaceRepeatingTimer(String ruleName,

--- a/src/test/java/org/openhab/binding/jrule/internal/codegenerator/JRuleActionClassGeneratorTest.java
+++ b/src/test/java/org/openhab/binding/jrule/internal/codegenerator/JRuleActionClassGeneratorTest.java
@@ -10,7 +10,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package org.openhab.binding.jrule.internal;
+package org.openhab.binding.jrule.internal.codegenerator;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -30,7 +30,7 @@ import org.junit.jupiter.api.TestInstance;
 import org.openhab.automation.jrule.actions.JRuleActionClassGenerator;
 import org.openhab.automation.jrule.internal.JRuleConfig;
 import org.openhab.automation.jrule.internal.compiler.JRuleCompiler;
-import org.openhab.binding.jrule.internal.test.MyThingActions;
+import org.openhab.binding.jrule.internal.thingaction.MyThingActions;
 import org.openhab.core.magic.binding.handler.MagicActionModuleThingHandler;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingTypeUID;

--- a/src/test/java/org/openhab/binding/jrule/internal/codegenerator/JRuleItemClassGeneratorTest.java
+++ b/src/test/java/org/openhab/binding/jrule/internal/codegenerator/JRuleItemClassGeneratorTest.java
@@ -10,7 +10,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package org.openhab.binding.jrule.internal;
+package org.openhab.binding.jrule.internal.codegenerator;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 

--- a/src/test/java/org/openhab/binding/jrule/internal/codegenerator/JRuleThingClassGeneratorTest.java
+++ b/src/test/java/org/openhab/binding/jrule/internal/codegenerator/JRuleThingClassGeneratorTest.java
@@ -10,7 +10,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package org.openhab.binding.jrule.internal;
+package org.openhab.binding.jrule.internal.codegenerator;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 

--- a/src/test/java/org/openhab/binding/jrule/internal/thingaction/MyThingActions.java
+++ b/src/test/java/org/openhab/binding/jrule/internal/thingaction/MyThingActions.java
@@ -10,7 +10,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package org.openhab.binding.jrule.internal.test;
+package org.openhab.binding.jrule.internal.thingaction;
 
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.automation.annotation.ActionInput;

--- a/src/test/java/org/openhab/binding/jrule/internal/triggers/JRuleAbstractTest.java
+++ b/src/test/java/org/openhab/binding/jrule/internal/triggers/JRuleAbstractTest.java
@@ -1,3 +1,15 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.openhab.binding.jrule.internal.triggers;
 
 import java.util.HashMap;
@@ -12,6 +24,12 @@ import org.openhab.automation.jrule.internal.test.JRuleMockedEventBus;
 import org.openhab.automation.jrule.rules.JRule;
 import org.openhab.core.events.Event;
 
+/**
+ * The {@link JRuleAbstractTest} is a base class for simple rule trigger testing
+ *
+ *
+ * @author Arne Seime - Initial contribution
+ */
 public abstract class JRuleAbstractTest {
     @BeforeAll
     public static void initEngine() {

--- a/src/test/java/org/openhab/binding/jrule/internal/triggers/JRuleAbstractTest.java
+++ b/src/test/java/org/openhab/binding/jrule/internal/triggers/JRuleAbstractTest.java
@@ -1,0 +1,37 @@
+package org.openhab.binding.jrule.internal.triggers;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.mockito.Mockito;
+import org.openhab.automation.jrule.internal.JRuleConfig;
+import org.openhab.automation.jrule.internal.engine.JRuleEngine;
+import org.openhab.automation.jrule.internal.test.JRuleMockedEventBus;
+import org.openhab.automation.jrule.rules.JRule;
+import org.openhab.core.events.Event;
+
+public abstract class JRuleAbstractTest {
+    @BeforeAll
+    public static void initEngine() {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("org.openhab.automation.jrule.engine.executors.enable", "false");
+        JRuleConfig config = new JRuleConfig(properties);
+        config.initConfig();
+
+        JRuleEngine engine = JRuleEngine.get();
+        engine.setConfig(config);
+    }
+
+    protected <T extends JRule> T initRule(T rule) {
+        T spyRule = Mockito.spy(rule);
+        JRuleEngine.get().add(spyRule);
+        return spyRule;
+    }
+
+    protected void fireEvents(List<Event> events) {
+        JRuleMockedEventBus eventBus = new JRuleMockedEventBus(events);
+        eventBus.start();
+    }
+}

--- a/src/test/java/org/openhab/binding/jrule/internal/triggers/itemchange/JRuleItemChangeRules.java
+++ b/src/test/java/org/openhab/binding/jrule/internal/triggers/itemchange/JRuleItemChangeRules.java
@@ -1,3 +1,15 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.openhab.binding.jrule.internal.triggers.itemchange;
 
 import org.openhab.automation.jrule.rules.JRule;
@@ -5,6 +17,12 @@ import org.openhab.automation.jrule.rules.JRuleName;
 import org.openhab.automation.jrule.rules.JRuleWhenItemChange;
 import org.openhab.automation.jrule.rules.event.JRuleEvent;
 
+/**
+ * The {@link JRuleItemChangeRules} contains rules for testing @JRuleWhenItemChange trigger
+ *
+ *
+ * @author Arne Seime - Initial contribution
+ */
 public class JRuleItemChangeRules extends JRule {
 
     public static final String ITEM = "item";

--- a/src/test/java/org/openhab/binding/jrule/internal/triggers/itemchange/JRuleItemChangeRules.java
+++ b/src/test/java/org/openhab/binding/jrule/internal/triggers/itemchange/JRuleItemChangeRules.java
@@ -1,0 +1,34 @@
+package org.openhab.binding.jrule.internal.triggers.itemchange;
+
+import org.openhab.automation.jrule.rules.JRule;
+import org.openhab.automation.jrule.rules.JRuleName;
+import org.openhab.automation.jrule.rules.JRuleWhenItemChange;
+import org.openhab.automation.jrule.rules.event.JRuleEvent;
+
+public class JRuleItemChangeRules extends JRule {
+
+    public static final String ITEM = "item";
+    public static final String ITEM_FROM = "item_from";
+    public static final String ITEM_TO = "item_to";
+    public static final String ITEM_FROM_TO = "item_from_to";
+
+    @JRuleName("Test JRuleWhenItemChange")
+    @JRuleWhenItemChange(item = ITEM)
+    public void itemChange(JRuleEvent event) {
+    }
+
+    @JRuleName("Test JRuleWhenItemChange/from")
+    @JRuleWhenItemChange(item = ITEM_FROM, from = "1")
+    public void itemChangeFrom(JRuleEvent event) {
+    }
+
+    @JRuleName("Test JRuleWhenItemChange/to")
+    @JRuleWhenItemChange(item = ITEM_TO, to = "1")
+    public void itemChangeTo(JRuleEvent event) {
+    }
+
+    @JRuleName("Test JRuleWhenItemChange/from/to")
+    @JRuleWhenItemChange(item = ITEM_FROM_TO, from = "1", to = "2")
+    public void itemChangeFromTo(JRuleEvent event) {
+    }
+}

--- a/src/test/java/org/openhab/binding/jrule/internal/triggers/itemchange/JRuleItemChangeTest.java
+++ b/src/test/java/org/openhab/binding/jrule/internal/triggers/itemchange/JRuleItemChangeTest.java
@@ -1,3 +1,15 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.openhab.binding.jrule.internal.triggers.itemchange;
 
 import static org.mockito.Mockito.times;
@@ -13,6 +25,12 @@ import org.openhab.core.events.Event;
 import org.openhab.core.items.events.ItemEventFactory;
 import org.openhab.core.library.types.StringType;
 
+/**
+ * The {@link JRuleItemChangeRules} contains tests for @JRuleWhenItemChange trigger
+ *
+ *
+ * @author Arne Seime - Initial contribution
+ */
 public class JRuleItemChangeTest extends JRuleAbstractTest {
 
     @Test

--- a/src/test/java/org/openhab/binding/jrule/internal/triggers/itemchange/JRuleItemChangeTest.java
+++ b/src/test/java/org/openhab/binding/jrule/internal/triggers/itemchange/JRuleItemChangeTest.java
@@ -1,0 +1,59 @@
+package org.openhab.binding.jrule.internal.triggers.itemchange;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.openhab.automation.jrule.rules.event.JRuleEvent;
+import org.openhab.binding.jrule.internal.triggers.JRuleAbstractTest;
+import org.openhab.core.events.Event;
+import org.openhab.core.items.events.ItemEventFactory;
+import org.openhab.core.library.types.StringType;
+
+public class JRuleItemChangeTest extends JRuleAbstractTest {
+
+    @Test
+    public void testItemChange_no_from_to() {
+        JRuleItemChangeRules rule = initRule(new JRuleItemChangeRules());
+        // Only last event should trigger rule method
+        fireEvents(
+                List.of(itemChangeEvent("other_item", "2", "1"), itemChangeEvent(JRuleItemChangeRules.ITEM, "2", "1")));
+        verify(rule, times(1)).itemChange(Mockito.any(JRuleEvent.class));
+    }
+
+    @Test
+    public void testItemChange_from() {
+        JRuleItemChangeRules rule = initRule(new JRuleItemChangeRules());
+        // Only last event should trigger rule method
+        fireEvents(List.of(itemChangeEvent(JRuleItemChangeRules.ITEM_FROM, "2", "1"),
+                itemChangeEvent(JRuleItemChangeRules.ITEM_FROM, "1", "2")));
+        verify(rule, times(1)).itemChangeFrom(Mockito.any(JRuleEvent.class));
+    }
+
+    @Test
+    public void testItemChange_to() {
+        JRuleItemChangeRules rule = initRule(new JRuleItemChangeRules());
+        // Only last event should trigger rule method
+        fireEvents(List.of(itemChangeEvent(JRuleItemChangeRules.ITEM_TO, "1", "2"),
+                itemChangeEvent(JRuleItemChangeRules.ITEM_TO, "2", "1")));
+        verify(rule, times(1)).itemChangeTo(Mockito.any(JRuleEvent.class));
+    }
+
+    @Test
+    public void testItemChange_from_to() {
+        JRuleItemChangeRules rule = initRule(new JRuleItemChangeRules());
+        // Only last event should trigger rule method
+        fireEvents(List.of(itemChangeEvent(JRuleItemChangeRules.ITEM_FROM_TO, "2", "1"),
+                itemChangeEvent(JRuleItemChangeRules.ITEM_FROM_TO, "3", "2"),
+                itemChangeEvent(JRuleItemChangeRules.ITEM_FROM_TO, "1", "2")));
+        verify(rule, times(1)).itemChangeFromTo(Mockito.any(JRuleEvent.class));
+    }
+
+    // Syntactic sugar
+    private Event itemChangeEvent(String item, String from, String to) {
+        return ItemEventFactory.createStateChangedEvent(item, new StringType(to), new StringType(from));
+    }
+}

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -8,7 +8,7 @@
     </encoder>
   </appender>
 
-  <root level="debug">
+  <root level="INFO">
     <appender-ref ref="STDOUT"/>
   </root>
 </configuration>


### PR DESCRIPTION
Some cleanup in the testing department.

Added JRuleItemChange tests (at least a few). But code mainly serves as an example on how testcases could be written. 

Plenty of room for improvements, but IMHO a step in the right direction.