### PR TITLE
Junit test for duplicate rule invocations

### DIFF
--- a/src/test/java/org/openhab/binding/jrule/internal/rules/JRuleAbstractTest.java
+++ b/src/test/java/org/openhab/binding/jrule/internal/rules/JRuleAbstractTest.java
@@ -64,6 +64,7 @@ public abstract class JRuleAbstractTest {
 
     protected <T extends JRule> T initRule(Class<T> rule) {
         T spyRule = Mockito.spy(rule);
+        JRuleEngine.get().reset();
         return spyRule;
     }
 

--- a/src/test/java/org/openhab/binding/jrule/internal/rules/JRuleAbstractTest.java
+++ b/src/test/java/org/openhab/binding/jrule/internal/rules/JRuleAbstractTest.java
@@ -65,6 +65,7 @@ public abstract class JRuleAbstractTest {
     protected <T extends JRule> T initRule(Class<T> rule) {
         T spyRule = Mockito.spy(rule);
         JRuleEngine.get().reset();
+        JRuleEngine.get().add(spyRule);
         return spyRule;
     }
 

--- a/src/test/java/org/openhab/binding/jrule/internal/rules/triggers/itemchange/JRuleItemChangeRules.java
+++ b/src/test/java/org/openhab/binding/jrule/internal/rules/triggers/itemchange/JRuleItemChangeRules.java
@@ -29,6 +29,7 @@ public class JRuleItemChangeRules extends JRule {
     public static final String ITEM_FROM = "item_from";
     public static final String ITEM_TO = "item_to";
     public static final String ITEM_FROM_TO = "item_from_to";
+    public static final String ITEM_DUPLICATE = "item_duplicate";
 
     @JRuleName("Test JRuleWhenItemChange")
     @JRuleWhenItemChange(item = ITEM)
@@ -48,5 +49,11 @@ public class JRuleItemChangeRules extends JRule {
     @JRuleName("Test JRuleWhenItemChange/from/to")
     @JRuleWhenItemChange(item = ITEM_FROM_TO, from = "1", to = "2")
     public void itemChangeFromTo(JRuleEvent event) {
+    }
+
+    @JRuleName("Test JRuleWhenItemChange/multiple")
+    @JRuleWhenItemChange(item = ITEM_DUPLICATE, to = "1")
+    @JRuleWhenItemChange(item = ITEM_DUPLICATE)
+    public void duplicateMatchingWhen(JRuleEvent event) {
     }
 }

--- a/src/test/java/org/openhab/binding/jrule/internal/rules/triggers/itemchange/JRuleItemChangeTest.java
+++ b/src/test/java/org/openhab/binding/jrule/internal/rules/triggers/itemchange/JRuleItemChangeTest.java
@@ -86,7 +86,6 @@ public class JRuleItemChangeTest extends JRuleAbstractTest {
     @Test
     public void testItemChange_multipleMatchingContexts() {
         JRuleItemChangeRules rule = initRule(JRuleItemChangeRules.class);
-        // Only last event should trigger rule method
         fireEvents(List.of(itemChangeEvent(JRuleItemChangeRules.ITEM_DUPLICATE, "2", "1")));
         verify(rule, times(1)).duplicateMatchingWhen(Mockito.any(JRuleEvent.class));
     }

--- a/src/test/java/org/openhab/binding/jrule/internal/rules/triggers/itemchange/JRuleItemChangeTest.java
+++ b/src/test/java/org/openhab/binding/jrule/internal/rules/triggers/itemchange/JRuleItemChangeTest.java
@@ -17,7 +17,7 @@ import static org.mockito.Mockito.verify;
 
 import java.util.List;
 
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.mockito.Mockito;
@@ -37,9 +37,10 @@ import org.openhab.core.library.types.StringType;
  *
  * @author Arne Seime - Initial contribution
  */
+
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class JRuleItemChangeTest extends JRuleAbstractTest {
-    @BeforeAll
+    @BeforeEach
     public void initTestClass() throws ItemNotFoundException {
         Mockito.when(itemRegistry.getItem(Mockito.anyString()))
                 .then((Answer<Item>) invocationOnMock -> new StringItem(invocationOnMock.getArgument(0)));
@@ -80,6 +81,14 @@ public class JRuleItemChangeTest extends JRuleAbstractTest {
                 itemChangeEvent(JRuleItemChangeRules.ITEM_FROM_TO, "3", "2"),
                 itemChangeEvent(JRuleItemChangeRules.ITEM_FROM_TO, "1", "2")));
         verify(rule, times(1)).itemChangeFromTo(Mockito.any(JRuleEvent.class));
+    }
+
+    @Test
+    public void testItemChange_multipleMatchingContexts() {
+        JRuleItemChangeRules rule = initRule(JRuleItemChangeRules.class);
+        // Only last event should trigger rule method
+        fireEvents(List.of(itemChangeEvent(JRuleItemChangeRules.ITEM_DUPLICATE, "2", "1")));
+        verify(rule, times(1)).duplicateMatchingWhen(Mockito.any(JRuleEvent.class));
     }
 
     // Syntactic sugar


### PR DESCRIPTION
This test fails.

The test defines 2 _overlapping_ JRuleWhen-conditions.
A _single_ event is fired - which matches both conditions.

Currently we invoke the rule method _twice_.

I would argue a _single_ invocation is correct, but this is not a bug but a design decision.

@querdenker2k @seaside1 