### PR TITLE
Extracting openhab-core.jar

### DIFF
--- a/src/main/java/org/openhab/automation/jrule/internal/compiler/JRuleCompiler.java
+++ b/src/main/java/org/openhab/automation/jrule/internal/compiler/JRuleCompiler.java
@@ -61,6 +61,7 @@ public class JRuleCompiler {
     private static final String JAVA_CLASS_PATH_PROPERTY = "java.class.path";
     private static final String CLASSPATH_OPTION = "-classpath";
     public static final String JAR_JRULE_NAME = "jrule.jar";
+    public static final String JAR_OPENHAB_CORE_NAME = "openhab-core.jar";
     public static final String JAR_JRULE_GENERATED_JAR_NAME = "jrule-generated.jar";
     private static final String LOG_NAME_COMPILER = "JRuleCompiler";
     private static final String FRONT_SLASH = "/";

--- a/src/main/java/org/openhab/automation/jrule/internal/compiler/JRuleJarExtractor.java
+++ b/src/main/java/org/openhab/automation/jrule/internal/compiler/JRuleJarExtractor.java
@@ -23,6 +23,7 @@ import java.net.URL;
 
 import org.openhab.automation.jrule.internal.JRuleLog;
 import org.openhab.automation.jrule.rules.JRule;
+import org.openhab.core.types.State;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,6 +41,16 @@ public class JRuleJarExtractor {
     public void extractJRuleJar(String jarFilePath) {
         try {
             final URL jarUrl = JRule.class.getProtectionDomain().getCodeSource().getLocation().toURI().toURL();
+            copyJRulesJarToFolder(jarUrl, jarFilePath);
+        } catch (MalformedURLException | URISyntaxException x) {
+            JRuleLog.error(logger, LOG_NAME_JAR, "Failed to extract jar due to uri exception jarFilePath: {} to: {}",
+                    jarFilePath, jarFilePath, x);
+        }
+    }
+
+    public void extractOpenhabCoreJar(String jarFilePath) {
+        try {
+            final URL jarUrl = State.class.getProtectionDomain().getCodeSource().getLocation().toURI().toURL();
             copyJRulesJarToFolder(jarUrl, jarFilePath);
         } catch (MalformedURLException | URISyntaxException x) {
             JRuleLog.error(logger, LOG_NAME_JAR, "Failed to extract jar due to uri exception jarFilePath: {} to: {}",

--- a/src/main/java/org/openhab/automation/jrule/internal/handler/JRuleHandler.java
+++ b/src/main/java/org/openhab/automation/jrule/internal/handler/JRuleHandler.java
@@ -183,8 +183,9 @@ public class JRuleHandler implements PropertyChangeListener {
 
         logInfo("Initializing JRule writing external Jars: {}", config.getJarDirectory());
 
-        // Extract and copy jrules.jar
+        // Extract and copy jrules.jar as well as openhab-core.jar
         jarExtractor.extractJRuleJar(compiler.getJarPath(JRuleCompiler.JAR_JRULE_NAME));
+        jarExtractor.extractOpenhabCoreJar(compiler.getJarPath(JRuleCompiler.JAR_OPENHAB_CORE_NAME));
 
         // Generate source files for all items and things
         Collection<Item> items = itemRegistry.getItems();


### PR DESCRIPTION
Now extracting the openhab-core.jar.
Possible we could merge dependencies for development of rules into one jar file