### PR TITLE
Memberitems type specific

### DIFF
--- a/src/main/java/org/openhab/automation/jrule/items/JRuleCallGroupItem.java
+++ b/src/main/java/org/openhab/automation/jrule/items/JRuleCallGroupItem.java
@@ -24,7 +24,7 @@ import org.openhab.automation.jrule.rules.value.JRuleStringListValue;
  *
  * @author Robert Delbrück - Initial contribution
  */
-public interface JRuleCallGroupItem extends JRuleCallItem, JRuleGroupItem {
+public interface JRuleCallGroupItem extends JRuleCallItem, JRuleGroupItem<JRuleCallItem> {
     static JRuleCallGroupItem forName(String itemName) throws JRuleItemNotFoundException {
         return JRuleItemRegistry.get(itemName, JRuleInternalCallGroupItem.class);
     }
@@ -34,6 +34,6 @@ public interface JRuleCallGroupItem extends JRuleCallItem, JRuleGroupItem {
     }
 
     default void postUpdate(JRuleStringListValue state) {
-        memberItemsGeneric().forEach(i -> i.postUncheckedUpdate(state));
+        memberItems().forEach(i -> i.postUncheckedUpdate(state));
     }
 }

--- a/src/main/java/org/openhab/automation/jrule/items/JRuleCallGroupItem.java
+++ b/src/main/java/org/openhab/automation/jrule/items/JRuleCallGroupItem.java
@@ -13,9 +13,12 @@
 package org.openhab.automation.jrule.items;
 
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.openhab.automation.jrule.exception.JRuleItemNotFoundException;
 import org.openhab.automation.jrule.internal.JRuleUtil;
+import org.openhab.automation.jrule.internal.handler.JRuleEventHandler;
 import org.openhab.automation.jrule.internal.items.JRuleInternalCallGroupItem;
 import org.openhab.automation.jrule.rules.value.JRuleStringListValue;
 
@@ -33,7 +36,16 @@ public interface JRuleCallGroupItem extends JRuleCallItem, JRuleGroupItem<JRuleC
         return Optional.ofNullable(JRuleUtil.forNameWrapExceptionAsNull(() -> forName(itemName)));
     }
 
+    default Set<JRuleCallItem> memberItems() {
+        return memberItems(false);
+    }
+
+    default Set<JRuleCallItem> memberItems(boolean recursive) {
+        return JRuleEventHandler.get().getGroupMemberItems(getName(), recursive).stream()
+                .map(jRuleItem -> (JRuleCallItem) jRuleItem).collect(Collectors.toSet());
+    }
+
     default void postUpdate(JRuleStringListValue state) {
-        memberItems().forEach(i -> i.postUncheckedUpdate(state));
+        JRuleEventHandler.get().getGroupMemberItems(getName(), false).forEach(i -> i.postUncheckedUpdate(state));
     }
 }

--- a/src/main/java/org/openhab/automation/jrule/items/JRuleColorGroupItem.java
+++ b/src/main/java/org/openhab/automation/jrule/items/JRuleColorGroupItem.java
@@ -24,7 +24,7 @@ import org.openhab.automation.jrule.rules.value.JRuleHsbValue;
  *
  * @author Robert Delbrück - Initial contribution
  */
-public interface JRuleColorGroupItem extends JRuleColorItem, JRuleDimmerGroupItem {
+public interface JRuleColorGroupItem extends JRuleColorItem, JRuleDimmerGroupItem<JRuleColorItem> {
     static JRuleColorGroupItem forName(String itemName) throws JRuleItemNotFoundException {
         return JRuleItemRegistry.get(itemName, JRuleInternalColorGroupItem.class);
     }
@@ -34,10 +34,10 @@ public interface JRuleColorGroupItem extends JRuleColorItem, JRuleDimmerGroupIte
     }
 
     default void sendCommand(JRuleHsbValue command) {
-        memberItemsGeneric().forEach(i -> i.sendUncheckedCommand(command));
+        this.memberItems().forEach(i -> i.sendUncheckedCommand(command));
     }
 
     default void postUpdate(JRuleHsbValue state) {
-        memberItemsGeneric().forEach(i -> i.postUncheckedUpdate(state));
+        this.memberItems().forEach(i -> i.postUncheckedUpdate(state));
     }
 }

--- a/src/main/java/org/openhab/automation/jrule/items/JRuleColorGroupItem.java
+++ b/src/main/java/org/openhab/automation/jrule/items/JRuleColorGroupItem.java
@@ -13,9 +13,12 @@
 package org.openhab.automation.jrule.items;
 
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.openhab.automation.jrule.exception.JRuleItemNotFoundException;
 import org.openhab.automation.jrule.internal.JRuleUtil;
+import org.openhab.automation.jrule.internal.handler.JRuleEventHandler;
 import org.openhab.automation.jrule.internal.items.JRuleInternalColorGroupItem;
 import org.openhab.automation.jrule.rules.value.JRuleHsbValue;
 
@@ -24,7 +27,7 @@ import org.openhab.automation.jrule.rules.value.JRuleHsbValue;
  *
  * @author Robert Delbrück - Initial contribution
  */
-public interface JRuleColorGroupItem extends JRuleColorItem, JRuleDimmerGroupItem<JRuleColorItem> {
+public interface JRuleColorGroupItem extends JRuleColorItem, JRuleDimmerGroupItem {
     static JRuleColorGroupItem forName(String itemName) throws JRuleItemNotFoundException {
         return JRuleItemRegistry.get(itemName, JRuleInternalColorGroupItem.class);
     }
@@ -33,11 +36,20 @@ public interface JRuleColorGroupItem extends JRuleColorItem, JRuleDimmerGroupIte
         return Optional.ofNullable(JRuleUtil.forNameWrapExceptionAsNull(() -> forName(itemName)));
     }
 
+    default Set<JRuleColorItem> memberItems() {
+        return memberItems(false);
+    }
+
+    default Set<JRuleColorItem> memberItems(boolean recursive) {
+        return JRuleEventHandler.get().getGroupMemberItems(getName(), recursive).stream()
+                .map(jRuleItem -> (JRuleColorItem) jRuleItem).collect(Collectors.toSet());
+    }
+
     default void sendCommand(JRuleHsbValue command) {
-        this.memberItems().forEach(i -> i.sendUncheckedCommand(command));
+        JRuleEventHandler.get().getGroupMemberItems(getName(), false).forEach(i -> i.sendUncheckedCommand(command));
     }
 
     default void postUpdate(JRuleHsbValue state) {
-        this.memberItems().forEach(i -> i.postUncheckedUpdate(state));
+        JRuleEventHandler.get().getGroupMemberItems(getName(), false).forEach(i -> i.postUncheckedUpdate(state));
     }
 }

--- a/src/main/java/org/openhab/automation/jrule/items/JRuleContactGroupItem.java
+++ b/src/main/java/org/openhab/automation/jrule/items/JRuleContactGroupItem.java
@@ -13,9 +13,12 @@
 package org.openhab.automation.jrule.items;
 
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.openhab.automation.jrule.exception.JRuleItemNotFoundException;
 import org.openhab.automation.jrule.internal.JRuleUtil;
+import org.openhab.automation.jrule.internal.handler.JRuleEventHandler;
 import org.openhab.automation.jrule.internal.items.JRuleInternalContactGroupItem;
 import org.openhab.automation.jrule.rules.value.JRuleOpenClosedValue;
 
@@ -33,7 +36,16 @@ public interface JRuleContactGroupItem extends JRuleContactItem, JRuleGroupItem<
         return Optional.ofNullable(JRuleUtil.forNameWrapExceptionAsNull(() -> forName(itemName)));
     }
 
+    default Set<JRuleContactItem> memberItems() {
+        return memberItems(false);
+    }
+
+    default Set<JRuleContactItem> memberItems(boolean recursive) {
+        return JRuleEventHandler.get().getGroupMemberItems(getName(), recursive).stream()
+                .map(jRuleItem -> (JRuleContactItem) jRuleItem).collect(Collectors.toSet());
+    }
+
     default void postUpdate(JRuleOpenClosedValue state) {
-        memberItems().forEach(i -> i.postUncheckedUpdate(state));
+        JRuleEventHandler.get().getGroupMemberItems(getName(), false).forEach(i -> i.postUncheckedUpdate(state));
     }
 }

--- a/src/main/java/org/openhab/automation/jrule/items/JRuleContactGroupItem.java
+++ b/src/main/java/org/openhab/automation/jrule/items/JRuleContactGroupItem.java
@@ -24,7 +24,7 @@ import org.openhab.automation.jrule.rules.value.JRuleOpenClosedValue;
  *
  * @author Robert Delbrück - Initial contribution
  */
-public interface JRuleContactGroupItem extends JRuleContactItem, JRuleGroupItem {
+public interface JRuleContactGroupItem extends JRuleContactItem, JRuleGroupItem<JRuleContactItem> {
     static JRuleContactGroupItem forName(String itemName) throws JRuleItemNotFoundException {
         return JRuleItemRegistry.get(itemName, JRuleInternalContactGroupItem.class);
     }
@@ -34,6 +34,6 @@ public interface JRuleContactGroupItem extends JRuleContactItem, JRuleGroupItem 
     }
 
     default void postUpdate(JRuleOpenClosedValue state) {
-        memberItemsGeneric().forEach(i -> i.postUncheckedUpdate(state));
+        memberItems().forEach(i -> i.postUncheckedUpdate(state));
     }
 }

--- a/src/main/java/org/openhab/automation/jrule/items/JRuleDateTimeGroupItem.java
+++ b/src/main/java/org/openhab/automation/jrule/items/JRuleDateTimeGroupItem.java
@@ -15,9 +15,12 @@ package org.openhab.automation.jrule.items;
 import java.time.ZonedDateTime;
 import java.util.Date;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.openhab.automation.jrule.exception.JRuleItemNotFoundException;
 import org.openhab.automation.jrule.internal.JRuleUtil;
+import org.openhab.automation.jrule.internal.handler.JRuleEventHandler;
 import org.openhab.automation.jrule.internal.items.JRuleInternalDateTimeGroupItem;
 import org.openhab.automation.jrule.rules.value.JRuleDateTimeValue;
 
@@ -35,27 +38,40 @@ public interface JRuleDateTimeGroupItem extends JRuleDateTimeItem, JRuleGroupIte
         return Optional.ofNullable(JRuleUtil.forNameWrapExceptionAsNull(() -> forName(itemName)));
     }
 
+    default Set<JRuleDateTimeItem> memberItems() {
+        return memberItems(false);
+    }
+
+    default Set<JRuleDateTimeItem> memberItems(boolean recursive) {
+        return JRuleEventHandler.get().getGroupMemberItems(getName(), recursive).stream()
+                .map(jRuleItem -> (JRuleDateTimeItem) jRuleItem).collect(Collectors.toSet());
+    }
+
     default void sendCommand(JRuleDateTimeValue command) {
-        memberItems().forEach(i -> i.sendUncheckedCommand(command));
+        JRuleEventHandler.get().getGroupMemberItems(getName(), false).forEach(i -> i.sendUncheckedCommand(command));
     }
 
     default void postUpdate(JRuleDateTimeValue state) {
-        memberItems().forEach(i -> i.postUncheckedUpdate(state));
+        JRuleEventHandler.get().getGroupMemberItems(getName(), false).forEach(i -> i.postUncheckedUpdate(state));
     }
 
     default void sendCommand(Date command) {
-        memberItems().forEach(i -> i.sendUncheckedCommand(new JRuleDateTimeValue(command)));
+        JRuleEventHandler.get().getGroupMemberItems(getName(), false)
+                .forEach(i -> i.sendUncheckedCommand(new JRuleDateTimeValue(command)));
     }
 
     default void sendCommand(ZonedDateTime command) {
-        memberItems().forEach(i -> i.sendUncheckedCommand(new JRuleDateTimeValue(command)));
+        JRuleEventHandler.get().getGroupMemberItems(getName(), false)
+                .forEach(i -> i.sendUncheckedCommand(new JRuleDateTimeValue(command)));
     }
 
     default void postUpdate(Date state) {
-        memberItems().forEach(i -> i.postUncheckedUpdate(new JRuleDateTimeValue(state)));
+        JRuleEventHandler.get().getGroupMemberItems(getName(), false)
+                .forEach(i -> i.postUncheckedUpdate(new JRuleDateTimeValue(state)));
     }
 
     default void postUpdate(ZonedDateTime state) {
-        memberItems().forEach(i -> i.postUncheckedUpdate(new JRuleDateTimeValue(state)));
+        JRuleEventHandler.get().getGroupMemberItems(getName(), false)
+                .forEach(i -> i.postUncheckedUpdate(new JRuleDateTimeValue(state)));
     }
 }

--- a/src/main/java/org/openhab/automation/jrule/items/JRuleDateTimeGroupItem.java
+++ b/src/main/java/org/openhab/automation/jrule/items/JRuleDateTimeGroupItem.java
@@ -26,7 +26,7 @@ import org.openhab.automation.jrule.rules.value.JRuleDateTimeValue;
  *
  * @author Robert Delbrück - Initial contribution
  */
-public interface JRuleDateTimeGroupItem extends JRuleDateTimeItem, JRuleGroupItem {
+public interface JRuleDateTimeGroupItem extends JRuleDateTimeItem, JRuleGroupItem<JRuleDateTimeItem> {
     static JRuleDateTimeGroupItem forName(String itemName) throws JRuleItemNotFoundException {
         return JRuleItemRegistry.get(itemName, JRuleInternalDateTimeGroupItem.class);
     }
@@ -36,26 +36,26 @@ public interface JRuleDateTimeGroupItem extends JRuleDateTimeItem, JRuleGroupIte
     }
 
     default void sendCommand(JRuleDateTimeValue command) {
-        memberItemsGeneric().forEach(i -> i.sendUncheckedCommand(command));
+        memberItems().forEach(i -> i.sendUncheckedCommand(command));
     }
 
     default void postUpdate(JRuleDateTimeValue state) {
-        memberItemsGeneric().forEach(i -> i.postUncheckedUpdate(state));
+        memberItems().forEach(i -> i.postUncheckedUpdate(state));
     }
 
     default void sendCommand(Date command) {
-        memberItemsGeneric().forEach(i -> i.sendUncheckedCommand(new JRuleDateTimeValue(command)));
+        memberItems().forEach(i -> i.sendUncheckedCommand(new JRuleDateTimeValue(command)));
     }
 
     default void sendCommand(ZonedDateTime command) {
-        memberItemsGeneric().forEach(i -> i.sendUncheckedCommand(new JRuleDateTimeValue(command)));
+        memberItems().forEach(i -> i.sendUncheckedCommand(new JRuleDateTimeValue(command)));
     }
 
     default void postUpdate(Date state) {
-        memberItemsGeneric().forEach(i -> i.postUncheckedUpdate(new JRuleDateTimeValue(state)));
+        memberItems().forEach(i -> i.postUncheckedUpdate(new JRuleDateTimeValue(state)));
     }
 
     default void postUpdate(ZonedDateTime state) {
-        memberItemsGeneric().forEach(i -> i.postUncheckedUpdate(new JRuleDateTimeValue(state)));
+        memberItems().forEach(i -> i.postUncheckedUpdate(new JRuleDateTimeValue(state)));
     }
 }

--- a/src/main/java/org/openhab/automation/jrule/items/JRuleDimmerGroupItem.java
+++ b/src/main/java/org/openhab/automation/jrule/items/JRuleDimmerGroupItem.java
@@ -13,9 +13,12 @@
 package org.openhab.automation.jrule.items;
 
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.openhab.automation.jrule.exception.JRuleItemNotFoundException;
 import org.openhab.automation.jrule.internal.JRuleUtil;
+import org.openhab.automation.jrule.internal.handler.JRuleEventHandler;
 import org.openhab.automation.jrule.internal.items.JRuleInternalDimmerGroupItem;
 import org.openhab.automation.jrule.rules.value.JRuleIncreaseDecreaseValue;
 import org.openhab.automation.jrule.rules.value.JRulePercentValue;
@@ -25,36 +28,47 @@ import org.openhab.automation.jrule.rules.value.JRulePercentValue;
  *
  * @author Robert Delbrück - Initial contribution
  */
-public interface JRuleDimmerGroupItem<I extends JRuleDimmerItem> extends JRuleDimmerItem, JRuleSwitchGroupItem<I> {
-    static JRuleDimmerGroupItem<JRuleDimmerItem> forName(String itemName) throws JRuleItemNotFoundException {
+public interface JRuleDimmerGroupItem extends JRuleDimmerItem, JRuleSwitchGroupItem {
+    static JRuleDimmerGroupItem forName(String itemName) throws JRuleItemNotFoundException {
         return JRuleItemRegistry.get(itemName, JRuleInternalDimmerGroupItem.class);
     }
 
-    static Optional<JRuleDimmerGroupItem<JRuleDimmerItem>> forNameOptional(String itemName) {
+    static Optional<JRuleDimmerGroupItem> forNameOptional(String itemName) {
         return Optional.ofNullable(JRuleUtil.forNameWrapExceptionAsNull(() -> forName(itemName)));
     }
 
+    default Set<? extends JRuleDimmerItem> memberItems() {
+        return memberItems(false);
+    }
+
+    default Set<? extends JRuleDimmerItem> memberItems(boolean recursive) {
+        return JRuleEventHandler.get().getGroupMemberItems(getName(), recursive).stream()
+                .map(jRuleItem -> (JRuleDimmerItem) jRuleItem).collect(Collectors.toSet());
+    }
+
     default void sendCommand(JRulePercentValue command) {
-        this.memberItems().forEach(i -> i.sendUncheckedCommand(command));
+        JRuleEventHandler.get().getGroupMemberItems(getName(), false).forEach(i -> i.sendUncheckedCommand(command));
     }
 
     default void postUpdate(JRulePercentValue state) {
-        this.memberItems().forEach(i -> i.postUncheckedUpdate(state));
+        JRuleEventHandler.get().getGroupMemberItems(getName(), false).forEach(i -> i.postUncheckedUpdate(state));
     }
 
     default void sendCommand(int command) {
-        this.memberItems().forEach(i -> i.sendUncheckedCommand(new JRulePercentValue(command)));
+        JRuleEventHandler.get().getGroupMemberItems(getName(), false)
+                .forEach(i -> i.sendUncheckedCommand(new JRulePercentValue(command)));
     }
 
     default void sendCommand(JRuleIncreaseDecreaseValue command) {
-        this.memberItems().forEach(i -> i.sendUncheckedCommand(command));
+        JRuleEventHandler.get().getGroupMemberItems(getName(), false).forEach(i -> i.sendUncheckedCommand(command));
     }
 
     default void postUpdate(JRuleIncreaseDecreaseValue state) {
-        this.memberItems().forEach(i -> i.postUncheckedUpdate(state));
+        JRuleEventHandler.get().getGroupMemberItems(getName(), false).forEach(i -> i.postUncheckedUpdate(state));
     }
 
     default void postUpdate(int state) {
-        this.memberItems().forEach(i -> i.postUncheckedUpdate(new JRulePercentValue(state)));
+        JRuleEventHandler.get().getGroupMemberItems(getName(), false)
+                .forEach(i -> i.postUncheckedUpdate(new JRulePercentValue(state)));
     }
 }

--- a/src/main/java/org/openhab/automation/jrule/items/JRuleDimmerGroupItem.java
+++ b/src/main/java/org/openhab/automation/jrule/items/JRuleDimmerGroupItem.java
@@ -25,36 +25,36 @@ import org.openhab.automation.jrule.rules.value.JRulePercentValue;
  *
  * @author Robert Delbrück - Initial contribution
  */
-public interface JRuleDimmerGroupItem extends JRuleDimmerItem, JRuleSwitchGroupItem {
-    static JRuleDimmerGroupItem forName(String itemName) throws JRuleItemNotFoundException {
+public interface JRuleDimmerGroupItem<I extends JRuleDimmerItem> extends JRuleDimmerItem, JRuleSwitchGroupItem<I> {
+    static JRuleDimmerGroupItem<JRuleDimmerItem> forName(String itemName) throws JRuleItemNotFoundException {
         return JRuleItemRegistry.get(itemName, JRuleInternalDimmerGroupItem.class);
     }
 
-    static Optional<JRuleDimmerGroupItem> forNameOptional(String itemName) {
+    static Optional<JRuleDimmerGroupItem<JRuleDimmerItem>> forNameOptional(String itemName) {
         return Optional.ofNullable(JRuleUtil.forNameWrapExceptionAsNull(() -> forName(itemName)));
     }
 
     default void sendCommand(JRulePercentValue command) {
-        memberItemsGeneric().forEach(i -> i.sendUncheckedCommand(command));
+        this.memberItems().forEach(i -> i.sendUncheckedCommand(command));
     }
 
     default void postUpdate(JRulePercentValue state) {
-        memberItemsGeneric().forEach(i -> i.postUncheckedUpdate(state));
+        this.memberItems().forEach(i -> i.postUncheckedUpdate(state));
     }
 
     default void sendCommand(int command) {
-        memberItemsGeneric().forEach(i -> i.sendUncheckedCommand(new JRulePercentValue(command)));
+        this.memberItems().forEach(i -> i.sendUncheckedCommand(new JRulePercentValue(command)));
     }
 
     default void sendCommand(JRuleIncreaseDecreaseValue command) {
-        memberItemsGeneric().forEach(i -> i.sendUncheckedCommand(command));
+        this.memberItems().forEach(i -> i.sendUncheckedCommand(command));
     }
 
     default void postUpdate(JRuleIncreaseDecreaseValue state) {
-        memberItemsGeneric().forEach(i -> i.postUncheckedUpdate(state));
+        this.memberItems().forEach(i -> i.postUncheckedUpdate(state));
     }
 
     default void postUpdate(int state) {
-        memberItemsGeneric().forEach(i -> i.postUncheckedUpdate(new JRulePercentValue(state)));
+        this.memberItems().forEach(i -> i.postUncheckedUpdate(new JRulePercentValue(state)));
     }
 }

--- a/src/main/java/org/openhab/automation/jrule/items/JRuleGroupItem.java
+++ b/src/main/java/org/openhab/automation/jrule/items/JRuleGroupItem.java
@@ -30,29 +30,28 @@ public interface JRuleGroupItem<I extends JRuleItem> extends JRuleItem {
         return JRuleEventHandler.get().getGroupMemberNames(getName(), false);
     }
 
-    default Set<I> memberItems() {
+    default Set<? extends JRuleItem> memberItems() {
         return memberItems(false);
     }
 
-    default Set<I> memberItems(boolean recursive) {
-        return JRuleEventHandler.get().getGroupMemberItems(getName(), recursive).stream()
-                .map(jRuleItem -> (I) jRuleItem).collect(Collectors.toSet());
+    default Set<? extends JRuleItem> memberItems(boolean recursive) {
+        return JRuleEventHandler.get().getGroupMemberItems(getName(), recursive).stream().collect(Collectors.toSet());
     }
 
     default void sendUncheckedCommand(JRuleValue command) {
-        memberItems().forEach(i -> i.sendUncheckedCommand(command));
+        JRuleEventHandler.get().getGroupMemberItems(getName(), false).forEach(i -> i.sendUncheckedCommand(command));
     }
 
     default void postUncheckedUpdate(JRuleValue state) {
-        memberItems().forEach(i -> i.postUncheckedUpdate(state));
+        JRuleEventHandler.get().getGroupMemberItems(getName(), false).forEach(i -> i.postUncheckedUpdate(state));
     }
 
     default void postUpdate(JRuleRefreshValue state) {
-        memberItems().forEach(i -> i.postUncheckedUpdate(state));
+        JRuleEventHandler.get().getGroupMemberItems(getName(), false).forEach(i -> i.postUncheckedUpdate(state));
     }
 
     default void postNullUpdate() {
-        memberItems().forEach(JRuleItem::postNullUpdate);
+        JRuleEventHandler.get().getGroupMemberItems(getName(), false).forEach(JRuleItem::postNullUpdate);
     }
 
     @Override

--- a/src/main/java/org/openhab/automation/jrule/items/JRuleGroupItem.java
+++ b/src/main/java/org/openhab/automation/jrule/items/JRuleGroupItem.java
@@ -13,6 +13,7 @@
 package org.openhab.automation.jrule.items;
 
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.openhab.automation.jrule.internal.handler.JRuleEventHandler;
 import org.openhab.automation.jrule.rules.value.JRuleRefreshValue;
@@ -23,42 +24,35 @@ import org.openhab.automation.jrule.rules.value.JRuleValue;
  *
  * @author Robert Delbrück - Initial contribution
  */
-public interface JRuleGroupItem extends JRuleItem {
+public interface JRuleGroupItem<I extends JRuleItem> extends JRuleItem {
     @Deprecated
     default Set<String> members() {
         return JRuleEventHandler.get().getGroupMemberNames(getName(), false);
     }
 
-    default Set<? extends JRuleItem> memberItems() {
-        return memberItemsGeneric(false);
+    default Set<I> memberItems() {
+        return memberItems(false);
     }
 
-    default Set<? extends JRuleItem> memberItems(boolean recursive) {
-        return JRuleEventHandler.get().getGroupMemberItems(getName(), recursive);
-    }
-
-    default Set<JRuleItem> memberItemsGeneric() {
-        return memberItemsGeneric(false);
-    }
-
-    default Set<JRuleItem> memberItemsGeneric(boolean recursive) {
-        return JRuleEventHandler.get().getGroupMemberItems(getName(), recursive);
+    default Set<I> memberItems(boolean recursive) {
+        return JRuleEventHandler.get().getGroupMemberItems(getName(), recursive).stream()
+                .map(jRuleItem -> (I) jRuleItem).collect(Collectors.toSet());
     }
 
     default void sendUncheckedCommand(JRuleValue command) {
-        memberItemsGeneric().forEach(i -> i.sendUncheckedCommand(command));
+        memberItems().forEach(i -> i.sendUncheckedCommand(command));
     }
 
     default void postUncheckedUpdate(JRuleValue state) {
-        memberItemsGeneric().forEach(i -> i.postUncheckedUpdate(state));
+        memberItems().forEach(i -> i.postUncheckedUpdate(state));
     }
 
     default void postUpdate(JRuleRefreshValue state) {
-        memberItemsGeneric().forEach(i -> i.postUncheckedUpdate(state));
+        memberItems().forEach(i -> i.postUncheckedUpdate(state));
     }
 
     default void postNullUpdate() {
-        memberItemsGeneric().forEach(i -> i.postUpdate(null));
+        memberItems().forEach(JRuleItem::postNullUpdate);
     }
 
     @Override

--- a/src/main/java/org/openhab/automation/jrule/items/JRuleImageGroupItem.java
+++ b/src/main/java/org/openhab/automation/jrule/items/JRuleImageGroupItem.java
@@ -13,9 +13,12 @@
 package org.openhab.automation.jrule.items;
 
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.openhab.automation.jrule.exception.JRuleItemNotFoundException;
 import org.openhab.automation.jrule.internal.JRuleUtil;
+import org.openhab.automation.jrule.internal.handler.JRuleEventHandler;
 import org.openhab.automation.jrule.internal.items.JRuleInternalImageGroupItem;
 import org.openhab.automation.jrule.rules.value.JRuleRawValue;
 
@@ -33,7 +36,16 @@ public interface JRuleImageGroupItem extends JRuleImageItem, JRuleGroupItem<JRul
         return Optional.ofNullable(JRuleUtil.forNameWrapExceptionAsNull(() -> forName(itemName)));
     }
 
+    default Set<JRuleImageItem> memberItems() {
+        return memberItems(false);
+    }
+
+    default Set<JRuleImageItem> memberItems(boolean recursive) {
+        return JRuleEventHandler.get().getGroupMemberItems(getName(), recursive).stream()
+                .map(jRuleItem -> (JRuleImageItem) jRuleItem).collect(Collectors.toSet());
+    }
+
     default void postUpdate(JRuleRawValue state) {
-        memberItems().forEach(i -> i.postUncheckedUpdate(state));
+        JRuleEventHandler.get().getGroupMemberItems(getName(), false).forEach(i -> i.postUncheckedUpdate(state));
     }
 }

--- a/src/main/java/org/openhab/automation/jrule/items/JRuleImageGroupItem.java
+++ b/src/main/java/org/openhab/automation/jrule/items/JRuleImageGroupItem.java
@@ -24,7 +24,7 @@ import org.openhab.automation.jrule.rules.value.JRuleRawValue;
  *
  * @author Robert Delbrück - Initial contribution
  */
-public interface JRuleImageGroupItem extends JRuleImageItem, JRuleGroupItem {
+public interface JRuleImageGroupItem extends JRuleImageItem, JRuleGroupItem<JRuleImageItem> {
     static JRuleImageGroupItem forName(String itemName) throws JRuleItemNotFoundException {
         return JRuleItemRegistry.get(itemName, JRuleInternalImageGroupItem.class);
     }
@@ -34,6 +34,6 @@ public interface JRuleImageGroupItem extends JRuleImageItem, JRuleGroupItem {
     }
 
     default void postUpdate(JRuleRawValue state) {
-        memberItemsGeneric().forEach(i -> i.postUncheckedUpdate(state));
+        memberItems().forEach(i -> i.postUncheckedUpdate(state));
     }
 }

--- a/src/main/java/org/openhab/automation/jrule/items/JRuleLocationGroupItem.java
+++ b/src/main/java/org/openhab/automation/jrule/items/JRuleLocationGroupItem.java
@@ -24,7 +24,7 @@ import org.openhab.automation.jrule.rules.value.JRulePointValue;
  *
  * @author Robert Delbrück - Initial contribution
  */
-public interface JRuleLocationGroupItem extends JRuleLocationItem, JRuleGroupItem {
+public interface JRuleLocationGroupItem extends JRuleLocationItem, JRuleGroupItem<JRuleLocationItem> {
     static JRuleLocationGroupItem forName(String itemName) throws JRuleItemNotFoundException {
         return JRuleItemRegistry.get(itemName, JRuleInternalLocationGroupItem.class);
     }
@@ -34,10 +34,10 @@ public interface JRuleLocationGroupItem extends JRuleLocationItem, JRuleGroupIte
     }
 
     default void sendCommand(JRulePointValue command) {
-        memberItemsGeneric().forEach(i -> i.sendUncheckedCommand(command));
+        memberItems().forEach(i -> i.sendUncheckedCommand(command));
     }
 
     default void postUpdate(JRulePointValue state) {
-        memberItemsGeneric().forEach(i -> i.postUncheckedUpdate(state));
+        memberItems().forEach(i -> i.postUncheckedUpdate(state));
     }
 }

--- a/src/main/java/org/openhab/automation/jrule/items/JRuleLocationGroupItem.java
+++ b/src/main/java/org/openhab/automation/jrule/items/JRuleLocationGroupItem.java
@@ -13,9 +13,12 @@
 package org.openhab.automation.jrule.items;
 
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.openhab.automation.jrule.exception.JRuleItemNotFoundException;
 import org.openhab.automation.jrule.internal.JRuleUtil;
+import org.openhab.automation.jrule.internal.handler.JRuleEventHandler;
 import org.openhab.automation.jrule.internal.items.JRuleInternalLocationGroupItem;
 import org.openhab.automation.jrule.rules.value.JRulePointValue;
 
@@ -33,11 +36,20 @@ public interface JRuleLocationGroupItem extends JRuleLocationItem, JRuleGroupIte
         return Optional.ofNullable(JRuleUtil.forNameWrapExceptionAsNull(() -> forName(itemName)));
     }
 
+    default Set<JRuleLocationItem> memberItems() {
+        return memberItems(false);
+    }
+
+    default Set<JRuleLocationItem> memberItems(boolean recursive) {
+        return JRuleEventHandler.get().getGroupMemberItems(getName(), recursive).stream()
+                .map(jRuleItem -> (JRuleLocationItem) jRuleItem).collect(Collectors.toSet());
+    }
+
     default void sendCommand(JRulePointValue command) {
-        memberItems().forEach(i -> i.sendUncheckedCommand(command));
+        JRuleEventHandler.get().getGroupMemberItems(getName(), false).forEach(i -> i.sendUncheckedCommand(command));
     }
 
     default void postUpdate(JRulePointValue state) {
-        memberItems().forEach(i -> i.postUncheckedUpdate(state));
+        JRuleEventHandler.get().getGroupMemberItems(getName(), false).forEach(i -> i.postUncheckedUpdate(state));
     }
 }

--- a/src/main/java/org/openhab/automation/jrule/items/JRuleNumberGroupItem.java
+++ b/src/main/java/org/openhab/automation/jrule/items/JRuleNumberGroupItem.java
@@ -24,7 +24,7 @@ import org.openhab.automation.jrule.rules.value.JRuleDecimalValue;
  *
  * @author Robert Delbrück - Initial contribution
  */
-public interface JRuleNumberGroupItem extends JRuleNumberItem, JRuleGroupItem {
+public interface JRuleNumberGroupItem extends JRuleNumberItem, JRuleGroupItem<JRuleNumberItem> {
     static JRuleNumberGroupItem forName(String itemName) throws JRuleItemNotFoundException {
         return JRuleItemRegistry.get(itemName, JRuleInternalNumberGroupItem.class);
     }
@@ -34,26 +34,26 @@ public interface JRuleNumberGroupItem extends JRuleNumberItem, JRuleGroupItem {
     }
 
     default void sendCommand(JRuleDecimalValue command) {
-        memberItemsGeneric().forEach(i -> i.sendUncheckedCommand(command));
+        memberItems().forEach(i -> i.sendUncheckedCommand(command));
     }
 
     default void postUpdate(JRuleDecimalValue state) {
-        memberItemsGeneric().forEach(i -> i.postUncheckedUpdate(state));
+        memberItems().forEach(i -> i.postUncheckedUpdate(state));
     }
 
     default void sendCommand(double command) {
-        memberItemsGeneric().forEach(i -> i.sendUncheckedCommand(new JRuleDecimalValue(command)));
+        memberItems().forEach(i -> i.sendUncheckedCommand(new JRuleDecimalValue(command)));
     }
 
     default void sendCommand(int command) {
-        memberItemsGeneric().forEach(i -> i.sendUncheckedCommand(new JRuleDecimalValue(command)));
+        memberItems().forEach(i -> i.sendUncheckedCommand(new JRuleDecimalValue(command)));
     }
 
     default void postUpdate(double state) {
-        memberItemsGeneric().forEach(i -> i.postUncheckedUpdate(new JRuleDecimalValue(state)));
+        memberItems().forEach(i -> i.postUncheckedUpdate(new JRuleDecimalValue(state)));
     }
 
     default void postUpdate(int state) {
-        memberItemsGeneric().forEach(i -> i.postUncheckedUpdate(new JRuleDecimalValue(state)));
+        memberItems().forEach(i -> i.postUncheckedUpdate(new JRuleDecimalValue(state)));
     }
 }

--- a/src/main/java/org/openhab/automation/jrule/items/JRuleNumberGroupItem.java
+++ b/src/main/java/org/openhab/automation/jrule/items/JRuleNumberGroupItem.java
@@ -13,9 +13,12 @@
 package org.openhab.automation.jrule.items;
 
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.openhab.automation.jrule.exception.JRuleItemNotFoundException;
 import org.openhab.automation.jrule.internal.JRuleUtil;
+import org.openhab.automation.jrule.internal.handler.JRuleEventHandler;
 import org.openhab.automation.jrule.internal.items.JRuleInternalNumberGroupItem;
 import org.openhab.automation.jrule.rules.value.JRuleDecimalValue;
 
@@ -33,27 +36,40 @@ public interface JRuleNumberGroupItem extends JRuleNumberItem, JRuleGroupItem<JR
         return Optional.ofNullable(JRuleUtil.forNameWrapExceptionAsNull(() -> forName(itemName)));
     }
 
+    default Set<JRuleNumberItem> memberItems() {
+        return memberItems(false);
+    }
+
+    default Set<JRuleNumberItem> memberItems(boolean recursive) {
+        return JRuleEventHandler.get().getGroupMemberItems(getName(), recursive).stream()
+                .map(jRuleItem -> (JRuleNumberItem) jRuleItem).collect(Collectors.toSet());
+    }
+
     default void sendCommand(JRuleDecimalValue command) {
-        memberItems().forEach(i -> i.sendUncheckedCommand(command));
+        JRuleEventHandler.get().getGroupMemberItems(getName(), false).forEach(i -> i.sendUncheckedCommand(command));
     }
 
     default void postUpdate(JRuleDecimalValue state) {
-        memberItems().forEach(i -> i.postUncheckedUpdate(state));
+        JRuleEventHandler.get().getGroupMemberItems(getName(), false).forEach(i -> i.postUncheckedUpdate(state));
     }
 
     default void sendCommand(double command) {
-        memberItems().forEach(i -> i.sendUncheckedCommand(new JRuleDecimalValue(command)));
+        JRuleEventHandler.get().getGroupMemberItems(getName(), false)
+                .forEach(i -> i.sendUncheckedCommand(new JRuleDecimalValue(command)));
     }
 
     default void sendCommand(int command) {
-        memberItems().forEach(i -> i.sendUncheckedCommand(new JRuleDecimalValue(command)));
+        JRuleEventHandler.get().getGroupMemberItems(getName(), false)
+                .forEach(i -> i.sendUncheckedCommand(new JRuleDecimalValue(command)));
     }
 
     default void postUpdate(double state) {
-        memberItems().forEach(i -> i.postUncheckedUpdate(new JRuleDecimalValue(state)));
+        JRuleEventHandler.get().getGroupMemberItems(getName(), false)
+                .forEach(i -> i.postUncheckedUpdate(new JRuleDecimalValue(state)));
     }
 
     default void postUpdate(int state) {
-        memberItems().forEach(i -> i.postUncheckedUpdate(new JRuleDecimalValue(state)));
+        JRuleEventHandler.get().getGroupMemberItems(getName(), false)
+                .forEach(i -> i.postUncheckedUpdate(new JRuleDecimalValue(state)));
     }
 }

--- a/src/main/java/org/openhab/automation/jrule/items/JRulePlayerGroupItem.java
+++ b/src/main/java/org/openhab/automation/jrule/items/JRulePlayerGroupItem.java
@@ -24,7 +24,7 @@ import org.openhab.automation.jrule.rules.value.*;
  *
  * @author Robert Delbrück - Initial contribution
  */
-public interface JRulePlayerGroupItem extends JRulePlayerItem, JRuleGroupItem {
+public interface JRulePlayerGroupItem extends JRulePlayerItem, JRuleGroupItem<JRulePlayerItem> {
     static JRulePlayerGroupItem forName(String itemName) throws JRuleItemNotFoundException {
         return JRuleItemRegistry.get(itemName, JRuleInternalPlayerGroupItem.class);
     }
@@ -34,18 +34,18 @@ public interface JRulePlayerGroupItem extends JRulePlayerItem, JRuleGroupItem {
     }
 
     default void sendCommand(JRulePlayPauseValue command) {
-        memberItemsGeneric().forEach(i -> i.sendUncheckedCommand(command));
+        memberItems().forEach(i -> i.sendUncheckedCommand(command));
     }
 
     default void postUpdate(JRulePlayPauseValue state) {
-        memberItemsGeneric().forEach(i -> i.postUncheckedUpdate(state));
+        memberItems().forEach(i -> i.postUncheckedUpdate(state));
     }
 
     default void sendCommand(JRuleRewindFastforwardValue command) {
-        memberItemsGeneric().forEach(i -> i.sendUncheckedCommand(command));
+        memberItems().forEach(i -> i.sendUncheckedCommand(command));
     }
 
     default void sendCommand(JRuleNextPreviousValue command) {
-        memberItemsGeneric().forEach(i -> i.sendUncheckedCommand(command));
+        memberItems().forEach(i -> i.sendUncheckedCommand(command));
     }
 }

--- a/src/main/java/org/openhab/automation/jrule/items/JRulePlayerGroupItem.java
+++ b/src/main/java/org/openhab/automation/jrule/items/JRulePlayerGroupItem.java
@@ -13,9 +13,12 @@
 package org.openhab.automation.jrule.items;
 
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.openhab.automation.jrule.exception.JRuleItemNotFoundException;
 import org.openhab.automation.jrule.internal.JRuleUtil;
+import org.openhab.automation.jrule.internal.handler.JRuleEventHandler;
 import org.openhab.automation.jrule.internal.items.JRuleInternalPlayerGroupItem;
 import org.openhab.automation.jrule.rules.value.*;
 
@@ -33,19 +36,28 @@ public interface JRulePlayerGroupItem extends JRulePlayerItem, JRuleGroupItem<JR
         return Optional.ofNullable(JRuleUtil.forNameWrapExceptionAsNull(() -> forName(itemName)));
     }
 
+    default Set<JRulePlayerItem> memberItems() {
+        return memberItems(false);
+    }
+
+    default Set<JRulePlayerItem> memberItems(boolean recursive) {
+        return JRuleEventHandler.get().getGroupMemberItems(getName(), recursive).stream()
+                .map(jRuleItem -> (JRulePlayerItem) jRuleItem).collect(Collectors.toSet());
+    }
+
     default void sendCommand(JRulePlayPauseValue command) {
-        memberItems().forEach(i -> i.sendUncheckedCommand(command));
+        JRuleEventHandler.get().getGroupMemberItems(getName(), false).forEach(i -> i.sendUncheckedCommand(command));
     }
 
     default void postUpdate(JRulePlayPauseValue state) {
-        memberItems().forEach(i -> i.postUncheckedUpdate(state));
+        JRuleEventHandler.get().getGroupMemberItems(getName(), false).forEach(i -> i.postUncheckedUpdate(state));
     }
 
     default void sendCommand(JRuleRewindFastforwardValue command) {
-        memberItems().forEach(i -> i.sendUncheckedCommand(command));
+        JRuleEventHandler.get().getGroupMemberItems(getName(), false).forEach(i -> i.sendUncheckedCommand(command));
     }
 
     default void sendCommand(JRuleNextPreviousValue command) {
-        memberItems().forEach(i -> i.sendUncheckedCommand(command));
+        JRuleEventHandler.get().getGroupMemberItems(getName(), false).forEach(i -> i.sendUncheckedCommand(command));
     }
 }

--- a/src/main/java/org/openhab/automation/jrule/items/JRuleQuantityGroupItem.java
+++ b/src/main/java/org/openhab/automation/jrule/items/JRuleQuantityGroupItem.java
@@ -13,9 +13,12 @@
 package org.openhab.automation.jrule.items;
 
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.openhab.automation.jrule.exception.JRuleItemNotFoundException;
 import org.openhab.automation.jrule.internal.JRuleUtil;
+import org.openhab.automation.jrule.internal.handler.JRuleEventHandler;
 import org.openhab.automation.jrule.internal.items.JRuleInternalQuantityGroupItem;
 import org.openhab.automation.jrule.rules.value.JRuleQuantityValue;
 
@@ -33,27 +36,40 @@ public interface JRuleQuantityGroupItem extends JRuleQuantityItem, JRuleGroupIte
         return Optional.ofNullable(JRuleUtil.forNameWrapExceptionAsNull(() -> forName(itemName)));
     }
 
+    default Set<JRuleQuantityItem> memberItems() {
+        return memberItems(false);
+    }
+
+    default Set<JRuleQuantityItem> memberItems(boolean recursive) {
+        return JRuleEventHandler.get().getGroupMemberItems(getName(), recursive).stream()
+                .map(jRuleItem -> (JRuleQuantityItem) jRuleItem).collect(Collectors.toSet());
+    }
+
     default void sendCommand(JRuleQuantityValue command) {
-        memberItems().forEach(i -> i.sendUncheckedCommand(command));
+        JRuleEventHandler.get().getGroupMemberItems(getName(), false).forEach(i -> i.sendUncheckedCommand(command));
     }
 
     default void sendCommand(double command, String unit) {
-        memberItems().forEach(i -> i.sendUncheckedCommand(new JRuleQuantityValue(command, unit)));
+        JRuleEventHandler.get().getGroupMemberItems(getName(), false)
+                .forEach(i -> i.sendUncheckedCommand(new JRuleQuantityValue(command, unit)));
     }
 
     default void sendCommand(int command, String unit) {
-        memberItems().forEach(i -> i.sendUncheckedCommand(new JRuleQuantityValue(command, unit)));
+        JRuleEventHandler.get().getGroupMemberItems(getName(), false)
+                .forEach(i -> i.sendUncheckedCommand(new JRuleQuantityValue(command, unit)));
     }
 
     default void postUpdate(JRuleQuantityValue state) {
-        memberItems().forEach(i -> i.postUncheckedUpdate(state));
+        JRuleEventHandler.get().getGroupMemberItems(getName(), false).forEach(i -> i.postUncheckedUpdate(state));
     }
 
     default void postUpdate(double state, String unit) {
-        memberItems().forEach(i -> i.postUncheckedUpdate(new JRuleQuantityValue(state, unit)));
+        JRuleEventHandler.get().getGroupMemberItems(getName(), false)
+                .forEach(i -> i.postUncheckedUpdate(new JRuleQuantityValue(state, unit)));
     }
 
     default void postUpdate(int state, String unit) {
-        memberItems().forEach(i -> i.postUncheckedUpdate(new JRuleQuantityValue(state, unit)));
+        JRuleEventHandler.get().getGroupMemberItems(getName(), false)
+                .forEach(i -> i.postUncheckedUpdate(new JRuleQuantityValue(state, unit)));
     }
 }

--- a/src/main/java/org/openhab/automation/jrule/items/JRuleQuantityGroupItem.java
+++ b/src/main/java/org/openhab/automation/jrule/items/JRuleQuantityGroupItem.java
@@ -24,7 +24,7 @@ import org.openhab.automation.jrule.rules.value.JRuleQuantityValue;
  *
  * @author Robert Delbrück - Initial contribution
  */
-public interface JRuleQuantityGroupItem extends JRuleQuantityItem, JRuleGroupItem {
+public interface JRuleQuantityGroupItem extends JRuleQuantityItem, JRuleGroupItem<JRuleQuantityItem> {
     static JRuleQuantityGroupItem forName(String itemName) throws JRuleItemNotFoundException {
         return JRuleItemRegistry.get(itemName, JRuleInternalQuantityGroupItem.class);
     }
@@ -34,26 +34,26 @@ public interface JRuleQuantityGroupItem extends JRuleQuantityItem, JRuleGroupIte
     }
 
     default void sendCommand(JRuleQuantityValue command) {
-        memberItemsGeneric().forEach(i -> i.sendUncheckedCommand(command));
+        memberItems().forEach(i -> i.sendUncheckedCommand(command));
     }
 
     default void sendCommand(double command, String unit) {
-        memberItemsGeneric().forEach(i -> i.sendUncheckedCommand(new JRuleQuantityValue(command, unit)));
+        memberItems().forEach(i -> i.sendUncheckedCommand(new JRuleQuantityValue(command, unit)));
     }
 
     default void sendCommand(int command, String unit) {
-        memberItemsGeneric().forEach(i -> i.sendUncheckedCommand(new JRuleQuantityValue(command, unit)));
+        memberItems().forEach(i -> i.sendUncheckedCommand(new JRuleQuantityValue(command, unit)));
     }
 
     default void postUpdate(JRuleQuantityValue state) {
-        memberItemsGeneric().forEach(i -> i.postUncheckedUpdate(state));
+        memberItems().forEach(i -> i.postUncheckedUpdate(state));
     }
 
     default void postUpdate(double state, String unit) {
-        memberItemsGeneric().forEach(i -> i.postUncheckedUpdate(new JRuleQuantityValue(state, unit)));
+        memberItems().forEach(i -> i.postUncheckedUpdate(new JRuleQuantityValue(state, unit)));
     }
 
     default void postUpdate(int state, String unit) {
-        memberItemsGeneric().forEach(i -> i.postUncheckedUpdate(new JRuleQuantityValue(state, unit)));
+        memberItems().forEach(i -> i.postUncheckedUpdate(new JRuleQuantityValue(state, unit)));
     }
 }

--- a/src/main/java/org/openhab/automation/jrule/items/JRuleRollershutterGroupItem.java
+++ b/src/main/java/org/openhab/automation/jrule/items/JRuleRollershutterGroupItem.java
@@ -13,9 +13,12 @@
 package org.openhab.automation.jrule.items;
 
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.openhab.automation.jrule.exception.JRuleItemNotFoundException;
 import org.openhab.automation.jrule.internal.JRuleUtil;
+import org.openhab.automation.jrule.internal.handler.JRuleEventHandler;
 import org.openhab.automation.jrule.internal.items.JRuleInternalRollershutterGroupItem;
 import org.openhab.automation.jrule.rules.value.*;
 
@@ -33,27 +36,38 @@ public interface JRuleRollershutterGroupItem extends JRuleRollershutterItem, JRu
         return Optional.ofNullable(JRuleUtil.forNameWrapExceptionAsNull(() -> forName(itemName)));
     }
 
+    default Set<JRuleRollershutterItem> memberItems() {
+        return memberItems(false);
+    }
+
+    default Set<JRuleRollershutterItem> memberItems(boolean recursive) {
+        return JRuleEventHandler.get().getGroupMemberItems(getName(), recursive).stream()
+                .map(jRuleItem -> (JRuleRollershutterItem) jRuleItem).collect(Collectors.toSet());
+    }
+
     default void sendCommand(JRulePercentValue command) {
-        memberItems().forEach(i -> i.sendUncheckedCommand(command));
+        JRuleEventHandler.get().getGroupMemberItems(getName(), false).forEach(i -> i.sendUncheckedCommand(command));
     }
 
     default void postUpdate(JRulePercentValue state) {
-        memberItems().forEach(i -> i.postUncheckedUpdate(state));
+        JRuleEventHandler.get().getGroupMemberItems(getName(), false).forEach(i -> i.postUncheckedUpdate(state));
     }
 
     default void sendCommand(int command) {
-        memberItems().forEach(i -> i.sendUncheckedCommand(new JRulePercentValue(command)));
+        JRuleEventHandler.get().getGroupMemberItems(getName(), false)
+                .forEach(i -> i.sendUncheckedCommand(new JRulePercentValue(command)));
     }
 
     default void sendCommand(JRuleUpDownValue command) {
-        memberItems().forEach(i -> i.sendUncheckedCommand(command));
+        JRuleEventHandler.get().getGroupMemberItems(getName(), false).forEach(i -> i.sendUncheckedCommand(command));
     }
 
     default void sendCommand(JRuleStopMoveValue command) {
-        memberItems().forEach(i -> i.sendUncheckedCommand(command));
+        JRuleEventHandler.get().getGroupMemberItems(getName(), false).forEach(i -> i.sendUncheckedCommand(command));
     }
 
     default void postUpdate(int state) {
-        memberItems().forEach(i -> i.postUncheckedUpdate(new JRulePercentValue(state)));
+        JRuleEventHandler.get().getGroupMemberItems(getName(), false)
+                .forEach(i -> i.postUncheckedUpdate(new JRulePercentValue(state)));
     }
 }

--- a/src/main/java/org/openhab/automation/jrule/items/JRuleRollershutterGroupItem.java
+++ b/src/main/java/org/openhab/automation/jrule/items/JRuleRollershutterGroupItem.java
@@ -24,7 +24,7 @@ import org.openhab.automation.jrule.rules.value.*;
  *
  * @author Robert Delbrück - Initial contribution
  */
-public interface JRuleRollershutterGroupItem extends JRuleRollershutterItem, JRuleGroupItem {
+public interface JRuleRollershutterGroupItem extends JRuleRollershutterItem, JRuleGroupItem<JRuleRollershutterItem> {
     static JRuleRollershutterGroupItem forName(String itemName) throws JRuleItemNotFoundException {
         return JRuleItemRegistry.get(itemName, JRuleInternalRollershutterGroupItem.class);
     }
@@ -34,26 +34,26 @@ public interface JRuleRollershutterGroupItem extends JRuleRollershutterItem, JRu
     }
 
     default void sendCommand(JRulePercentValue command) {
-        memberItemsGeneric().forEach(i -> i.sendUncheckedCommand(command));
+        memberItems().forEach(i -> i.sendUncheckedCommand(command));
     }
 
     default void postUpdate(JRulePercentValue state) {
-        memberItemsGeneric().forEach(i -> i.postUncheckedUpdate(state));
+        memberItems().forEach(i -> i.postUncheckedUpdate(state));
     }
 
     default void sendCommand(int command) {
-        memberItemsGeneric().forEach(i -> i.sendUncheckedCommand(new JRulePercentValue(command)));
+        memberItems().forEach(i -> i.sendUncheckedCommand(new JRulePercentValue(command)));
     }
 
     default void sendCommand(JRuleUpDownValue command) {
-        memberItemsGeneric().forEach(i -> i.sendUncheckedCommand(command));
+        memberItems().forEach(i -> i.sendUncheckedCommand(command));
     }
 
     default void sendCommand(JRuleStopMoveValue command) {
-        memberItemsGeneric().forEach(i -> i.sendUncheckedCommand(command));
+        memberItems().forEach(i -> i.sendUncheckedCommand(command));
     }
 
     default void postUpdate(int state) {
-        memberItemsGeneric().forEach(i -> i.postUncheckedUpdate(new JRulePercentValue(state)));
+        memberItems().forEach(i -> i.postUncheckedUpdate(new JRulePercentValue(state)));
     }
 }

--- a/src/main/java/org/openhab/automation/jrule/items/JRuleStringGroupItem.java
+++ b/src/main/java/org/openhab/automation/jrule/items/JRuleStringGroupItem.java
@@ -13,9 +13,12 @@
 package org.openhab.automation.jrule.items;
 
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.openhab.automation.jrule.exception.JRuleItemNotFoundException;
 import org.openhab.automation.jrule.internal.JRuleUtil;
+import org.openhab.automation.jrule.internal.handler.JRuleEventHandler;
 import org.openhab.automation.jrule.internal.items.JRuleInternalStringGroupItem;
 import org.openhab.automation.jrule.rules.value.JRuleStringValue;
 
@@ -33,19 +36,30 @@ public interface JRuleStringGroupItem extends JRuleStringItem, JRuleGroupItem<JR
         return Optional.ofNullable(JRuleUtil.forNameWrapExceptionAsNull(() -> forName(itemName)));
     }
 
+    default Set<JRuleStringItem> memberItems() {
+        return memberItems(false);
+    }
+
+    default Set<JRuleStringItem> memberItems(boolean recursive) {
+        return JRuleEventHandler.get().getGroupMemberItems(getName(), recursive).stream()
+                .map(jRuleItem -> (JRuleStringItem) jRuleItem).collect(Collectors.toSet());
+    }
+
     default void sendCommand(JRuleStringValue command) {
-        memberItems().forEach(i -> i.sendUncheckedCommand(command));
+        JRuleEventHandler.get().getGroupMemberItems(getName(), false).forEach(i -> i.sendUncheckedCommand(command));
     }
 
     default void postUpdate(JRuleStringValue state) {
-        memberItems().forEach(i -> i.postUncheckedUpdate(state));
+        JRuleEventHandler.get().getGroupMemberItems(getName(), false).forEach(i -> i.postUncheckedUpdate(state));
     }
 
     default void sendCommand(String command) {
-        memberItems().forEach(i -> i.sendUncheckedCommand(new JRuleStringValue(command)));
+        JRuleEventHandler.get().getGroupMemberItems(getName(), false)
+                .forEach(i -> i.sendUncheckedCommand(new JRuleStringValue(command)));
     }
 
     default void postUpdate(String state) {
-        memberItems().forEach(m -> m.postUncheckedUpdate(new JRuleStringValue(state)));
+        JRuleEventHandler.get().getGroupMemberItems(getName(), false)
+                .forEach(m -> m.postUncheckedUpdate(new JRuleStringValue(state)));
     }
 }

--- a/src/main/java/org/openhab/automation/jrule/items/JRuleStringGroupItem.java
+++ b/src/main/java/org/openhab/automation/jrule/items/JRuleStringGroupItem.java
@@ -24,7 +24,7 @@ import org.openhab.automation.jrule.rules.value.JRuleStringValue;
  *
  * @author Robert Delbrück - Initial contribution
  */
-public interface JRuleStringGroupItem extends JRuleStringItem, JRuleGroupItem {
+public interface JRuleStringGroupItem extends JRuleStringItem, JRuleGroupItem<JRuleStringItem> {
     static JRuleStringGroupItem forName(String itemName) throws JRuleItemNotFoundException {
         return JRuleItemRegistry.get(itemName, JRuleInternalStringGroupItem.class);
     }
@@ -34,18 +34,18 @@ public interface JRuleStringGroupItem extends JRuleStringItem, JRuleGroupItem {
     }
 
     default void sendCommand(JRuleStringValue command) {
-        memberItemsGeneric().forEach(i -> i.sendUncheckedCommand(command));
+        memberItems().forEach(i -> i.sendUncheckedCommand(command));
     }
 
     default void postUpdate(JRuleStringValue state) {
-        memberItemsGeneric().forEach(i -> i.postUncheckedUpdate(state));
+        memberItems().forEach(i -> i.postUncheckedUpdate(state));
     }
 
     default void sendCommand(String command) {
-        memberItemsGeneric().forEach(i -> i.sendUncheckedCommand(new JRuleStringValue(command)));
+        memberItems().forEach(i -> i.sendUncheckedCommand(new JRuleStringValue(command)));
     }
 
     default void postUpdate(String state) {
-        memberItemsGeneric().forEach(m -> m.postUncheckedUpdate(new JRuleStringValue(state)));
+        memberItems().forEach(m -> m.postUncheckedUpdate(new JRuleStringValue(state)));
     }
 }

--- a/src/main/java/org/openhab/automation/jrule/items/JRuleSwitchGroupItem.java
+++ b/src/main/java/org/openhab/automation/jrule/items/JRuleSwitchGroupItem.java
@@ -13,12 +13,9 @@
 package org.openhab.automation.jrule.items;
 
 import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.openhab.automation.jrule.exception.JRuleItemNotFoundException;
 import org.openhab.automation.jrule.internal.JRuleUtil;
-import org.openhab.automation.jrule.internal.handler.JRuleEventHandler;
 import org.openhab.automation.jrule.internal.items.JRuleInternalSwitchGroupItem;
 import org.openhab.automation.jrule.rules.value.JRuleOnOffValue;
 
@@ -27,37 +24,28 @@ import org.openhab.automation.jrule.rules.value.JRuleOnOffValue;
  *
  * @author Robert Delbrück - Initial contribution
  */
-public interface JRuleSwitchGroupItem extends JRuleSwitchItem, JRuleGroupItem {
-    static JRuleSwitchGroupItem forName(String itemName) throws JRuleItemNotFoundException {
+public interface JRuleSwitchGroupItem<I extends JRuleSwitchItem> extends JRuleSwitchItem, JRuleGroupItem<I> {
+    static JRuleSwitchGroupItem<JRuleSwitchItem> forName(String itemName) throws JRuleItemNotFoundException {
         return JRuleItemRegistry.get(itemName, JRuleInternalSwitchGroupItem.class);
     }
 
-    static Optional<JRuleSwitchGroupItem> forNameOptional(String itemName) {
+    static Optional<JRuleSwitchGroupItem<JRuleSwitchItem>> forNameOptional(String itemName) {
         return Optional.ofNullable(JRuleUtil.forNameWrapExceptionAsNull(() -> forName(itemName)));
     }
 
-    default Set<JRuleSwitchItem> memberItems() {
-        return memberItems(false);
-    }
-
-    default Set<JRuleSwitchItem> memberItems(boolean recursive) {
-        return JRuleEventHandler.get().getGroupMemberItems(getName(), recursive).stream().map(i -> (JRuleSwitchItem) i)
-                .collect(Collectors.toSet());
-    }
-
     default void sendCommand(JRuleOnOffValue command) {
-        memberItemsGeneric().forEach(i -> i.sendUncheckedCommand(command));
+        this.memberItems().forEach(i -> i.sendUncheckedCommand(command));
     }
 
     default void postUpdate(JRuleOnOffValue state) {
-        memberItemsGeneric().forEach(i -> i.postUncheckedUpdate(state));
+        this.memberItems().forEach(i -> i.postUncheckedUpdate(state));
     }
 
     default void sendCommand(boolean command) {
-        memberItemsGeneric().forEach(i -> i.sendUncheckedCommand(JRuleOnOffValue.valueOf(command)));
+        this.memberItems().forEach(i -> i.sendUncheckedCommand(JRuleOnOffValue.valueOf(command)));
     }
 
     default void postUpdate(boolean state) {
-        memberItemsGeneric().forEach(i -> i.postUncheckedUpdate(JRuleOnOffValue.valueOf(state)));
+        this.memberItems().forEach(i -> i.postUncheckedUpdate(JRuleOnOffValue.valueOf(state)));
     }
 }

--- a/src/main/java/org/openhab/automation/jrule/items/JRuleUnspecifiedGroupItem.java
+++ b/src/main/java/org/openhab/automation/jrule/items/JRuleUnspecifiedGroupItem.java
@@ -16,16 +16,16 @@ import java.util.Optional;
 
 import org.openhab.automation.jrule.exception.JRuleItemNotFoundException;
 import org.openhab.automation.jrule.internal.JRuleUtil;
-import org.openhab.automation.jrule.internal.items.JRuleInternalStringGroupItem;
+import org.openhab.automation.jrule.internal.items.JRuleInternalUnspecifiedGroupItem;
 
 /**
  * The {@link JRuleUnspecifiedGroupItem} Items
  *
  * @author Robert Delbrück - Initial contribution
  */
-public interface JRuleUnspecifiedGroupItem extends JRuleItem, JRuleGroupItem {
+public interface JRuleUnspecifiedGroupItem extends JRuleItem, JRuleGroupItem<JRuleItem> {
     static JRuleUnspecifiedGroupItem forName(String itemName) throws JRuleItemNotFoundException {
-        return JRuleItemRegistry.get(itemName, JRuleInternalStringGroupItem.class);
+        return JRuleItemRegistry.get(itemName, JRuleInternalUnspecifiedGroupItem.class);
     }
 
     static Optional<JRuleUnspecifiedGroupItem> forNameOptional(String itemName) {

--- a/src/main/java/org/openhab/automation/jrule/items/JRuleUnspecifiedGroupItem.java
+++ b/src/main/java/org/openhab/automation/jrule/items/JRuleUnspecifiedGroupItem.java
@@ -13,9 +13,12 @@
 package org.openhab.automation.jrule.items;
 
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.openhab.automation.jrule.exception.JRuleItemNotFoundException;
 import org.openhab.automation.jrule.internal.JRuleUtil;
+import org.openhab.automation.jrule.internal.handler.JRuleEventHandler;
 import org.openhab.automation.jrule.internal.items.JRuleInternalUnspecifiedGroupItem;
 
 /**
@@ -30,5 +33,13 @@ public interface JRuleUnspecifiedGroupItem extends JRuleItem, JRuleGroupItem<JRu
 
     static Optional<JRuleUnspecifiedGroupItem> forNameOptional(String itemName) {
         return Optional.ofNullable(JRuleUtil.forNameWrapExceptionAsNull(() -> forName(itemName)));
+    }
+
+    default Set<JRuleItem> memberItems() {
+        return memberItems(false);
+    }
+
+    default Set<JRuleItem> memberItems(boolean recursive) {
+        return JRuleEventHandler.get().getGroupMemberItems(getName(), recursive).stream().collect(Collectors.toSet());
     }
 }

--- a/src/test/java/org/openhab/automation/jrule/items/JRuleCallGroupItemTest.java
+++ b/src/test/java/org/openhab/automation/jrule/items/JRuleCallGroupItemTest.java
@@ -12,16 +12,29 @@
  */
 package org.openhab.automation.jrule.items;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.openhab.automation.jrule.internal.items.JRuleInternalCallGroupItem;
+import org.openhab.automation.jrule.rules.value.JRuleStringListValue;
 
 /**
  * The {@link JRuleCallGroupItemTest}
  *
  * @author Robert Delbrück - Initial contribution
  */
-class JRuleCallGroupItemTest extends JRuleCallItemTest {
+public class JRuleCallGroupItemTest extends JRuleCallItemTest {
     @Override
     protected JRuleItem getJRuleItem() {
         return new JRuleInternalCallGroupItem("Group", "Label", "Type", "Id");
+    }
+
+    @Test
+    public void testMemberOfGeneric() {
+        List<JRuleStringListValue> set = JRuleCallGroupItem.forName(GROUP_NAME).memberItems().stream()
+                .map(JRuleCallItem::getStateAsStringList).collect(Collectors.toList());
+        Assertions.assertEquals(3, set.size());
     }
 }

--- a/src/test/java/org/openhab/automation/jrule/items/JRuleCallItemTest.java
+++ b/src/test/java/org/openhab/automation/jrule/items/JRuleCallItemTest.java
@@ -24,6 +24,7 @@ import org.openhab.automation.jrule.rules.value.JRuleStringListValue;
 import org.openhab.automation.jrule.rules.value.JRuleValue;
 import org.openhab.core.items.GenericItem;
 import org.openhab.core.library.items.CallItem;
+import org.openhab.core.library.types.StringListType;
 
 /**
  * The {@link JRuleCallItemTest}
@@ -60,7 +61,9 @@ class JRuleCallItemTest extends JRuleItemTestBase {
 
     @Override
     protected GenericItem getOhItem(String name) {
-        return new CallItem(name);
+        CallItem item = new CallItem(name);
+        Optional.ofNullable(name).ifPresent(s -> item.setState(new StringListType(s)));
+        return item;
     }
 
     @Test
@@ -71,11 +74,11 @@ class JRuleCallItemTest extends JRuleItemTestBase {
         Assertions.assertFalse(JRuleCallItem.forNameOptional(ITEM_NON_EXISTING).isPresent());
     }
 
-    protected <T extends JRuleGroupItem> T groupForNameMethod(String name) {
+    protected <T extends JRuleGroupItem<? extends JRuleItem>> T groupForNameMethod(String name) {
         return (T) JRuleCallGroupItem.forName(name);
     }
 
-    protected <T extends JRuleGroupItem> Optional<T> groupForNameOptionalMethod(String name) {
+    protected <T extends JRuleGroupItem<? extends JRuleItem>> Optional<T> groupForNameOptionalMethod(String name) {
         return (Optional<T>) JRuleCallGroupItem.forNameOptional(name);
     }
 }

--- a/src/test/java/org/openhab/automation/jrule/items/JRuleColorGroupItemTest.java
+++ b/src/test/java/org/openhab/automation/jrule/items/JRuleColorGroupItemTest.java
@@ -12,7 +12,13 @@
  */
 package org.openhab.automation.jrule.items;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.openhab.automation.jrule.internal.items.JRuleInternalColorGroupItem;
+import org.openhab.automation.jrule.rules.value.JRuleHsbValue;
 
 /**
  * The {@link JRuleColorGroupItemTest}
@@ -23,5 +29,12 @@ class JRuleColorGroupItemTest extends JRuleColorItemTest {
     @Override
     protected JRuleItem getJRuleItem() {
         return new JRuleInternalColorGroupItem("Group", "Label", "Type", "Id");
+    }
+
+    @Test
+    public void testMemberOfGeneric() {
+        List<JRuleHsbValue> set = JRuleColorGroupItem.forName(GROUP_NAME).memberItems().stream()
+                .map(JRuleColorItem::getStateAsHsb).collect(Collectors.toList());
+        Assertions.assertEquals(3, set.size());
     }
 }

--- a/src/test/java/org/openhab/automation/jrule/items/JRuleColorItemTest.java
+++ b/src/test/java/org/openhab/automation/jrule/items/JRuleColorItemTest.java
@@ -151,11 +151,11 @@ class JRuleColorItemTest extends JRuleItemTestBase {
         Assertions.assertEquals(JRuleOnOffValue.ON, item.getStateAsOnOff());
     }
 
-    protected <T extends JRuleGroupItem> T groupForNameMethod(String name) {
+    protected <T extends JRuleGroupItem<? extends JRuleItem>> T groupForNameMethod(String name) {
         return (T) JRuleColorGroupItem.forName(name);
     }
 
-    protected <T extends JRuleGroupItem> Optional<T> groupForNameOptionalMethod(String name) {
+    protected <T extends JRuleGroupItem<? extends JRuleItem>> Optional<T> groupForNameOptionalMethod(String name) {
         return (Optional<T>) JRuleColorGroupItem.forNameOptional(name);
     }
 }

--- a/src/test/java/org/openhab/automation/jrule/items/JRuleContactGroupItemTest.java
+++ b/src/test/java/org/openhab/automation/jrule/items/JRuleContactGroupItemTest.java
@@ -12,7 +12,13 @@
  */
 package org.openhab.automation.jrule.items;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.openhab.automation.jrule.internal.items.JRuleInternalContactGroupItem;
+import org.openhab.automation.jrule.rules.value.JRuleOpenClosedValue;
 
 /**
  * The {@link JRuleContactGroupItemTest}
@@ -23,5 +29,12 @@ class JRuleContactGroupItemTest extends JRuleContactItemTest {
     @Override
     protected JRuleItem getJRuleItem() {
         return new JRuleInternalContactGroupItem("Group", "Label", "Type", "Id");
+    }
+
+    @Test
+    public void testMemberOfGeneric() {
+        List<JRuleOpenClosedValue> set = JRuleContactGroupItem.forName(GROUP_NAME).memberItems().stream()
+                .map(JRuleContactItem::getStateAsOpenClose).collect(Collectors.toList());
+        Assertions.assertEquals(3, set.size());
     }
 }

--- a/src/test/java/org/openhab/automation/jrule/items/JRuleContactItemTest.java
+++ b/src/test/java/org/openhab/automation/jrule/items/JRuleContactItemTest.java
@@ -69,11 +69,11 @@ class JRuleContactItemTest extends JRuleItemTestBase {
         Assertions.assertFalse(JRuleContactItem.forNameOptional(ITEM_NON_EXISTING).isPresent());
     }
 
-    protected <T extends JRuleGroupItem> T groupForNameMethod(String name) {
+    protected <T extends JRuleGroupItem<? extends JRuleItem>> T groupForNameMethod(String name) {
         return (T) JRuleContactGroupItem.forName(name);
     }
 
-    protected <T extends JRuleGroupItem> Optional<T> groupForNameOptionalMethod(String name) {
+    protected <T extends JRuleGroupItem<? extends JRuleItem>> Optional<T> groupForNameOptionalMethod(String name) {
         return (Optional<T>) JRuleContactGroupItem.forNameOptional(name);
     }
 }

--- a/src/test/java/org/openhab/automation/jrule/items/JRuleDateTimeGroupItemTest.java
+++ b/src/test/java/org/openhab/automation/jrule/items/JRuleDateTimeGroupItemTest.java
@@ -12,7 +12,13 @@
  */
 package org.openhab.automation.jrule.items;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.openhab.automation.jrule.internal.items.JRuleInternalDateTimeGroupItem;
+import org.openhab.automation.jrule.rules.value.JRuleDateTimeValue;
 
 /**
  * The {@link JRuleDateTimeGroupItemTest}
@@ -23,5 +29,12 @@ class JRuleDateTimeGroupItemTest extends JRuleDateTimeItemTest {
     @Override
     protected JRuleItem getJRuleItem() {
         return new JRuleInternalDateTimeGroupItem("Group", "Label", "Type", "Id");
+    }
+
+    @Test
+    public void testMemberOfGeneric() {
+        List<JRuleDateTimeValue> set = JRuleDateTimeGroupItem.forName(GROUP_NAME).memberItems().stream()
+                .map(JRuleDateTimeItem::getStateAsDateTime).collect(Collectors.toList());
+        Assertions.assertEquals(3, set.size());
     }
 }

--- a/src/test/java/org/openhab/automation/jrule/items/JRuleDateTimeItemTest.java
+++ b/src/test/java/org/openhab/automation/jrule/items/JRuleDateTimeItemTest.java
@@ -88,11 +88,11 @@ class JRuleDateTimeItemTest extends JRuleItemTestBase {
         Assertions.assertFalse(JRuleDateTimeItem.forNameOptional(ITEM_NON_EXISTING).isPresent());
     }
 
-    protected <T extends JRuleGroupItem> T groupForNameMethod(String name) {
+    protected <T extends JRuleGroupItem<? extends JRuleItem>> T groupForNameMethod(String name) {
         return (T) JRuleDateTimeGroupItem.forName(name);
     }
 
-    protected <T extends JRuleGroupItem> Optional<T> groupForNameOptionalMethod(String name) {
+    protected <T extends JRuleGroupItem<? extends JRuleItem>> Optional<T> groupForNameOptionalMethod(String name) {
         return (Optional<T>) JRuleDateTimeGroupItem.forNameOptional(name);
     }
 }

--- a/src/test/java/org/openhab/automation/jrule/items/JRuleDimmerGroupItemTest.java
+++ b/src/test/java/org/openhab/automation/jrule/items/JRuleDimmerGroupItemTest.java
@@ -12,7 +12,13 @@
  */
 package org.openhab.automation.jrule.items;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.openhab.automation.jrule.internal.items.JRuleInternalDimmerGroupItem;
+import org.openhab.automation.jrule.rules.value.JRulePercentValue;
 
 /**
  * The {@link JRuleDimmerGroupItemTest}
@@ -23,5 +29,12 @@ class JRuleDimmerGroupItemTest extends JRuleDimmerItemTest {
     @Override
     protected JRuleItem getJRuleItem() {
         return new JRuleInternalDimmerGroupItem("Group", "Label", "Type", "Id");
+    }
+
+    @Test
+    public void testMemberOfGeneric() {
+        List<JRulePercentValue> set = JRuleDimmerGroupItem.forName(GROUP_NAME).memberItems().stream()
+                .map(JRuleDimmerItem::getStateAsPercent).collect(Collectors.toList());
+        Assertions.assertEquals(3, set.size());
     }
 }

--- a/src/test/java/org/openhab/automation/jrule/items/JRuleDimmerItemTest.java
+++ b/src/test/java/org/openhab/automation/jrule/items/JRuleDimmerItemTest.java
@@ -118,11 +118,11 @@ class JRuleDimmerItemTest extends JRuleItemTestBase {
         Assertions.assertEquals(JRuleOnOffValue.ON, item.getStateAsOnOff());
     }
 
-    protected <T extends JRuleGroupItem> T groupForNameMethod(String name) {
+    protected <T extends JRuleGroupItem<? extends JRuleItem>> T groupForNameMethod(String name) {
         return (T) JRuleDimmerGroupItem.forName(name);
     }
 
-    protected <T extends JRuleGroupItem> Optional<T> groupForNameOptionalMethod(String name) {
+    protected <T extends JRuleGroupItem<? extends JRuleItem>> Optional<T> groupForNameOptionalMethod(String name) {
         return (Optional<T>) JRuleDimmerGroupItem.forNameOptional(name);
     }
 }

--- a/src/test/java/org/openhab/automation/jrule/items/JRuleImageGroupItemTest.java
+++ b/src/test/java/org/openhab/automation/jrule/items/JRuleImageGroupItemTest.java
@@ -12,7 +12,13 @@
  */
 package org.openhab.automation.jrule.items;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.openhab.automation.jrule.internal.items.JRuleInternalImageGroupItem;
+import org.openhab.automation.jrule.rules.value.JRuleRawValue;
 
 /**
  * The {@link JRuleImageGroupItemTest}
@@ -23,5 +29,12 @@ class JRuleImageGroupItemTest extends JRuleImageItemTest {
     @Override
     protected JRuleItem getJRuleItem() {
         return new JRuleInternalImageGroupItem("Group", "Label", "Type", "Id");
+    }
+
+    @Test
+    public void testMemberOfGeneric() {
+        List<JRuleRawValue> set = JRuleImageGroupItem.forName(GROUP_NAME).memberItems().stream()
+                .map(JRuleImageItem::getStateAsRaw).collect(Collectors.toList());
+        Assertions.assertEquals(3, set.size());
     }
 }

--- a/src/test/java/org/openhab/automation/jrule/items/JRuleImageItemTest.java
+++ b/src/test/java/org/openhab/automation/jrule/items/JRuleImageItemTest.java
@@ -66,11 +66,11 @@ class JRuleImageItemTest extends JRuleItemTestBase {
         Assertions.assertFalse(JRuleImageItem.forNameOptional(ITEM_NON_EXISTING).isPresent());
     }
 
-    protected <T extends JRuleGroupItem> T groupForNameMethod(String name) {
+    protected <T extends JRuleGroupItem<? extends JRuleItem>> T groupForNameMethod(String name) {
         return (T) JRuleImageGroupItem.forName(name);
     }
 
-    protected <T extends JRuleGroupItem> Optional<T> groupForNameOptionalMethod(String name) {
+    protected <T extends JRuleGroupItem<? extends JRuleItem>> Optional<T> groupForNameOptionalMethod(String name) {
         return (Optional<T>) JRuleImageGroupItem.forNameOptional(name);
     }
 }

--- a/src/test/java/org/openhab/automation/jrule/items/JRuleItemTestBase.java
+++ b/src/test/java/org/openhab/automation/jrule/items/JRuleItemTestBase.java
@@ -134,9 +134,10 @@ public abstract class JRuleItemTestBase {
         Assertions.assertFalse(groupForNameOptionalMethod(ITEM_NON_EXISTING).isPresent());
     }
 
-    protected abstract <T extends JRuleGroupItem> Optional<T> groupForNameOptionalMethod(String name);
+    protected abstract <T extends JRuleGroupItem<? extends JRuleItem>> Optional<T> groupForNameOptionalMethod(
+            String name);
 
-    protected abstract <T extends JRuleGroupItem> T groupForNameMethod(String name);
+    protected abstract <T extends JRuleGroupItem<? extends JRuleItem>> T groupForNameMethod(String name);
 
     @Test
     public void testMemberItems(TestInfo testInfo) {

--- a/src/test/java/org/openhab/automation/jrule/items/JRuleLocationGroupItemTest.java
+++ b/src/test/java/org/openhab/automation/jrule/items/JRuleLocationGroupItemTest.java
@@ -12,7 +12,13 @@
  */
 package org.openhab.automation.jrule.items;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.openhab.automation.jrule.internal.items.JRuleInternalLocationGroupItem;
+import org.openhab.automation.jrule.rules.value.JRulePointValue;
 
 /**
  * The {@link JRuleLocationGroupItemTest}
@@ -23,5 +29,12 @@ class JRuleLocationGroupItemTest extends JRuleLocationItemTest {
     @Override
     protected JRuleItem getJRuleItem() {
         return new JRuleInternalLocationGroupItem("Group", "Label", "Type", "Id");
+    }
+
+    @Test
+    public void testMemberOfGeneric() {
+        List<JRulePointValue> set = JRuleLocationGroupItem.forName(GROUP_NAME).memberItems().stream()
+                .map(JRuleLocationItem::getStateAsPoint).collect(Collectors.toList());
+        Assertions.assertEquals(3, set.size());
     }
 }

--- a/src/test/java/org/openhab/automation/jrule/items/JRuleLocationItemTest.java
+++ b/src/test/java/org/openhab/automation/jrule/items/JRuleLocationItemTest.java
@@ -91,11 +91,11 @@ class JRuleLocationItemTest extends JRuleItemTestBase {
         Assertions.assertFalse(JRuleLocationItem.forNameOptional(ITEM_NON_EXISTING).isPresent());
     }
 
-    protected <T extends JRuleGroupItem> T groupForNameMethod(String name) {
+    protected <T extends JRuleGroupItem<? extends JRuleItem>> T groupForNameMethod(String name) {
         return (T) JRuleLocationGroupItem.forName(name);
     }
 
-    protected <T extends JRuleGroupItem> Optional<T> groupForNameOptionalMethod(String name) {
+    protected <T extends JRuleGroupItem<? extends JRuleItem>> Optional<T> groupForNameOptionalMethod(String name) {
         return (Optional<T>) JRuleLocationGroupItem.forNameOptional(name);
     }
 }

--- a/src/test/java/org/openhab/automation/jrule/items/JRuleNumberGroupItemTest.java
+++ b/src/test/java/org/openhab/automation/jrule/items/JRuleNumberGroupItemTest.java
@@ -12,7 +12,13 @@
  */
 package org.openhab.automation.jrule.items;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.openhab.automation.jrule.internal.items.JRuleInternalNumberGroupItem;
+import org.openhab.automation.jrule.rules.value.JRuleDecimalValue;
 
 /**
  * The {@link JRuleNumberGroupItemTest}
@@ -23,5 +29,12 @@ class JRuleNumberGroupItemTest extends JRuleNumberItemTest {
     @Override
     protected JRuleItem getJRuleItem() {
         return new JRuleInternalNumberGroupItem("Group", "Label", "Type", "Id");
+    }
+
+    @Test
+    public void testMemberOfGeneric() {
+        List<JRuleDecimalValue> set = JRuleNumberGroupItem.forName(GROUP_NAME).memberItems().stream()
+                .map(JRuleNumberItem::getStateAsDecimal).collect(Collectors.toList());
+        Assertions.assertEquals(3, set.size());
     }
 }

--- a/src/test/java/org/openhab/automation/jrule/items/JRuleNumberItemTest.java
+++ b/src/test/java/org/openhab/automation/jrule/items/JRuleNumberItemTest.java
@@ -84,11 +84,11 @@ class JRuleNumberItemTest extends JRuleItemTestBase {
         Assertions.assertFalse(JRuleNumberItem.forNameOptional(ITEM_NON_EXISTING).isPresent());
     }
 
-    protected <T extends JRuleGroupItem> T groupForNameMethod(String name) {
+    protected <T extends JRuleGroupItem<? extends JRuleItem>> T groupForNameMethod(String name) {
         return (T) JRuleNumberGroupItem.forName(name);
     }
 
-    protected <T extends JRuleGroupItem> Optional<T> groupForNameOptionalMethod(String name) {
+    protected <T extends JRuleGroupItem<? extends JRuleItem>> Optional<T> groupForNameOptionalMethod(String name) {
         return (Optional<T>) JRuleNumberGroupItem.forNameOptional(name);
     }
 }

--- a/src/test/java/org/openhab/automation/jrule/items/JRulePlayerGroupItemTest.java
+++ b/src/test/java/org/openhab/automation/jrule/items/JRulePlayerGroupItemTest.java
@@ -18,7 +18,7 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.openhab.automation.jrule.internal.items.JRuleInternalPlayerGroupItem;
-import org.openhab.automation.jrule.rules.value.JRulePercentValue;
+import org.openhab.automation.jrule.rules.value.JRulePlayPauseValue;
 
 /**
  * The {@link JRulePlayerGroupItemTest}
@@ -33,8 +33,8 @@ class JRulePlayerGroupItemTest extends JRulePlayerItemTest {
 
     @Test
     public void testMemberOfGeneric() {
-        List<JRulePercentValue> set = JRuleDimmerGroupItem.forName(GROUP_NAME).memberItems().stream()
-                .map(JRuleDimmerItem::getStateAsPercent).collect(Collectors.toList());
+        List<JRulePlayPauseValue> set = JRulePlayerGroupItem.forName(GROUP_NAME).memberItems().stream()
+                .map(JRulePlayerItem::getStateAsPlayPause).collect(Collectors.toList());
         Assertions.assertEquals(3, set.size());
     }
 }

--- a/src/test/java/org/openhab/automation/jrule/items/JRulePlayerGroupItemTest.java
+++ b/src/test/java/org/openhab/automation/jrule/items/JRulePlayerGroupItemTest.java
@@ -12,7 +12,13 @@
  */
 package org.openhab.automation.jrule.items;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.openhab.automation.jrule.internal.items.JRuleInternalPlayerGroupItem;
+import org.openhab.automation.jrule.rules.value.JRulePercentValue;
 
 /**
  * The {@link JRulePlayerGroupItemTest}
@@ -23,5 +29,12 @@ class JRulePlayerGroupItemTest extends JRulePlayerItemTest {
     @Override
     protected JRuleItem getJRuleItem() {
         return new JRuleInternalPlayerGroupItem("Group", "Label", "Type", "Id");
+    }
+
+    @Test
+    public void testMemberOfGeneric() {
+        List<JRulePercentValue> set = JRuleDimmerGroupItem.forName(GROUP_NAME).memberItems().stream()
+                .map(JRuleDimmerItem::getStateAsPercent).collect(Collectors.toList());
+        Assertions.assertEquals(3, set.size());
     }
 }

--- a/src/test/java/org/openhab/automation/jrule/items/JRulePlayerItemTest.java
+++ b/src/test/java/org/openhab/automation/jrule/items/JRulePlayerItemTest.java
@@ -93,11 +93,11 @@ class JRulePlayerItemTest extends JRuleItemTestBase {
         Assertions.assertFalse(JRulePlayerItem.forNameOptional(ITEM_NON_EXISTING).isPresent());
     }
 
-    protected <T extends JRuleGroupItem> T groupForNameMethod(String name) {
+    protected <T extends JRuleGroupItem<? extends JRuleItem>> T groupForNameMethod(String name) {
         return (T) JRulePlayerGroupItem.forName(name);
     }
 
-    protected <T extends JRuleGroupItem> Optional<T> groupForNameOptionalMethod(String name) {
+    protected <T extends JRuleGroupItem<? extends JRuleItem>> Optional<T> groupForNameOptionalMethod(String name) {
         return (Optional<T>) JRulePlayerGroupItem.forNameOptional(name);
     }
 }

--- a/src/test/java/org/openhab/automation/jrule/items/JRuleQuantityGroupItemTest.java
+++ b/src/test/java/org/openhab/automation/jrule/items/JRuleQuantityGroupItemTest.java
@@ -12,7 +12,13 @@
  */
 package org.openhab.automation.jrule.items;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.openhab.automation.jrule.internal.items.JRuleInternalQuantityGroupItem;
+import org.openhab.automation.jrule.rules.value.JRuleQuantityValue;
 
 /**
  * The {@link JRuleQuantityGroupItemTest}
@@ -23,5 +29,12 @@ class JRuleQuantityGroupItemTest extends JRuleQuantityItemTest {
     @Override
     protected JRuleItem getJRuleItem() {
         return new JRuleInternalQuantityGroupItem("Group", "Label", "Type", "Id");
+    }
+
+    @Test
+    public void testMemberOfGeneric() {
+        List<JRuleQuantityValue> set = JRuleQuantityGroupItem.forName(GROUP_NAME).memberItems().stream()
+                .map(JRuleQuantityItem::getStateAsQuantity).collect(Collectors.toList());
+        Assertions.assertEquals(3, set.size());
     }
 }

--- a/src/test/java/org/openhab/automation/jrule/items/JRuleQuantityItemTest.java
+++ b/src/test/java/org/openhab/automation/jrule/items/JRuleQuantityItemTest.java
@@ -82,11 +82,11 @@ class JRuleQuantityItemTest extends JRuleItemTestBase {
         return new NumberItem("Number:ElectricPotential", name);
     }
 
-    protected <T extends JRuleGroupItem> T groupForNameMethod(String name) {
+    protected <T extends JRuleGroupItem<? extends JRuleItem>> T groupForNameMethod(String name) {
         return (T) JRuleQuantityGroupItem.forName(name);
     }
 
-    protected <T extends JRuleGroupItem> Optional<T> groupForNameOptionalMethod(String name) {
+    protected <T extends JRuleGroupItem<? extends JRuleItem>> Optional<T> groupForNameOptionalMethod(String name) {
         return (Optional<T>) JRuleQuantityGroupItem.forNameOptional(name);
     }
 }

--- a/src/test/java/org/openhab/automation/jrule/items/JRuleRollershutterGroupItemTest.java
+++ b/src/test/java/org/openhab/automation/jrule/items/JRuleRollershutterGroupItemTest.java
@@ -12,7 +12,13 @@
  */
 package org.openhab.automation.jrule.items;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.openhab.automation.jrule.internal.items.JRuleInternalRollershutterGroupItem;
+import org.openhab.automation.jrule.rules.value.JRulePercentValue;
 
 /**
  * The {@link JRuleRollershutterGroupItemTest}
@@ -23,5 +29,12 @@ class JRuleRollershutterGroupItemTest extends JRuleRollershutterItemTest {
     @Override
     protected JRuleItem getJRuleItem() {
         return new JRuleInternalRollershutterGroupItem("Group", "Label", "Type", "Id");
+    }
+
+    @Test
+    public void testMemberOfGeneric() {
+        List<JRulePercentValue> set = JRuleRollershutterGroupItem.forName(GROUP_NAME).memberItems().stream()
+                .map(JRuleRollershutterItem::getStateAsPercent).collect(Collectors.toList());
+        Assertions.assertEquals(3, set.size());
     }
 }

--- a/src/test/java/org/openhab/automation/jrule/items/JRuleRollershutterItemTest.java
+++ b/src/test/java/org/openhab/automation/jrule/items/JRuleRollershutterItemTest.java
@@ -105,11 +105,11 @@ class JRuleRollershutterItemTest extends JRuleItemTestBase {
         Assertions.assertFalse(JRuleRollershutterItem.forNameOptional(ITEM_NON_EXISTING).isPresent());
     }
 
-    protected <T extends JRuleGroupItem> T groupForNameMethod(String name) {
+    protected <T extends JRuleGroupItem<? extends JRuleItem>> T groupForNameMethod(String name) {
         return (T) JRuleRollershutterGroupItem.forName(name);
     }
 
-    protected <T extends JRuleGroupItem> Optional<T> groupForNameOptionalMethod(String name) {
+    protected <T extends JRuleGroupItem<? extends JRuleItem>> Optional<T> groupForNameOptionalMethod(String name) {
         return (Optional<T>) JRuleRollershutterGroupItem.forNameOptional(name);
     }
 }

--- a/src/test/java/org/openhab/automation/jrule/items/JRuleStringGroupItemTest.java
+++ b/src/test/java/org/openhab/automation/jrule/items/JRuleStringGroupItemTest.java
@@ -12,6 +12,11 @@
  */
 package org.openhab.automation.jrule.items;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.openhab.automation.jrule.internal.items.JRuleInternalStringGroupItem;
 
 /**
@@ -23,5 +28,12 @@ class JRuleStringGroupItemTest extends JRuleStringItemTest {
     @Override
     protected JRuleItem getJRuleItem() {
         return new JRuleInternalStringGroupItem("Group", "Label", "Type", "Id");
+    }
+
+    @Test
+    public void testMemberOfGeneric() {
+        List<String> set = JRuleStringGroupItem.forName(GROUP_NAME).memberItems().stream()
+                .map(JRuleStringItem::getStateAsString).collect(Collectors.toList());
+        Assertions.assertEquals(3, set.size());
     }
 }

--- a/src/test/java/org/openhab/automation/jrule/items/JRuleStringItemTest.java
+++ b/src/test/java/org/openhab/automation/jrule/items/JRuleStringItemTest.java
@@ -85,11 +85,11 @@ class JRuleStringItemTest extends JRuleItemTestBase {
         Assertions.assertFalse(JRuleStringItem.forNameOptional(ITEM_NON_EXISTING).isPresent());
     }
 
-    protected <T extends JRuleGroupItem> T groupForNameMethod(String name) {
+    protected <T extends JRuleGroupItem<? extends JRuleItem>> T groupForNameMethod(String name) {
         return (T) JRuleStringGroupItem.forName(name);
     }
 
-    protected <T extends JRuleGroupItem> Optional<T> groupForNameOptionalMethod(String name) {
+    protected <T extends JRuleGroupItem<? extends JRuleItem>> Optional<T> groupForNameOptionalMethod(String name) {
         return (Optional<T>) JRuleStringGroupItem.forNameOptional(name);
     }
 }

--- a/src/test/java/org/openhab/automation/jrule/items/JRuleSwitchGroupItemTest.java
+++ b/src/test/java/org/openhab/automation/jrule/items/JRuleSwitchGroupItemTest.java
@@ -12,7 +12,13 @@
  */
 package org.openhab.automation.jrule.items;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.openhab.automation.jrule.internal.items.JRuleInternalSwitchGroupItem;
+import org.openhab.automation.jrule.rules.value.JRuleOnOffValue;
 
 /**
  * The {@link JRuleSwitchGroupItemTest}
@@ -23,5 +29,12 @@ class JRuleSwitchGroupItemTest extends JRuleSwitchItemTest {
     @Override
     protected JRuleItem getJRuleItem() {
         return new JRuleInternalSwitchGroupItem("Group", "Label", "Type", "Id");
+    }
+
+    @Test
+    public void testMemberOfGeneric() {
+        List<JRuleOnOffValue> set = JRuleSwitchGroupItem.forName(GROUP_NAME).memberItems().stream()
+                .map(JRuleSwitchItem::getStateAsOnOff).collect(Collectors.toList());
+        Assertions.assertEquals(3, set.size());
     }
 }

--- a/src/test/java/org/openhab/automation/jrule/items/JRuleSwitchItemTest.java
+++ b/src/test/java/org/openhab/automation/jrule/items/JRuleSwitchItemTest.java
@@ -92,11 +92,11 @@ class JRuleSwitchItemTest extends JRuleItemTestBase {
         JRuleSwitchItem.forNameOptional(ITEM_NAME).ifPresent(item -> item.sendCommand(true));
     }
 
-    protected <T extends JRuleGroupItem> T groupForNameMethod(String name) {
+    protected <T extends JRuleGroupItem<? extends JRuleItem>> T groupForNameMethod(String name) {
         return (T) JRuleSwitchGroupItem.forName(name);
     }
 
-    protected <T extends JRuleGroupItem> Optional<T> groupForNameOptionalMethod(String name) {
+    protected <T extends JRuleGroupItem<? extends JRuleItem>> Optional<T> groupForNameOptionalMethod(String name) {
         return (Optional<T>) JRuleSwitchGroupItem.forNameOptional(name);
     }
 }

--- a/src/test/java/org/openhab/automation/jrule/items/JRuleUnspecifiedGroupItemTest.java
+++ b/src/test/java/org/openhab/automation/jrule/items/JRuleUnspecifiedGroupItemTest.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.automation.jrule.items;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.openhab.automation.jrule.internal.items.JRuleInternalSwitchGroupItem;
+import org.openhab.automation.jrule.rules.value.JRuleOnOffValue;
+import org.openhab.automation.jrule.rules.value.JRuleValue;
+import org.openhab.core.items.GenericItem;
+import org.openhab.core.library.items.SwitchItem;
+
+/**
+ * The {@link JRuleUnspecifiedGroupItemTest}
+ *
+ * @author Robert Delbrück - Initial contribution
+ */
+class JRuleUnspecifiedGroupItemTest extends JRuleItemTestBase {
+    @Override
+    protected JRuleItem getJRuleItem() {
+        return new JRuleInternalSwitchGroupItem("Group", "Label", "Type", "Id");
+    }
+
+    @Override
+    protected JRuleValue getDefaultCommand() {
+        return JRuleOnOffValue.ON;
+    }
+
+    @Override
+    protected GenericItem getOhItem(String name) {
+        return new SwitchItem(name);
+    }
+
+    @Override
+    protected <T extends JRuleGroupItem<? extends JRuleItem>> Optional<T> groupForNameOptionalMethod(String name) {
+        return (Optional<T>) JRuleSwitchGroupItem.forNameOptional(name);
+    }
+
+    @Override
+    protected <T extends JRuleGroupItem<? extends JRuleItem>> T groupForNameMethod(String name) {
+        return (T) JRuleSwitchGroupItem.forName(name);
+    }
+
+    @Test
+    public void testMemberOfGeneric() {
+        List<String> set = JRuleUnspecifiedGroupItem.forName(GROUP_NAME).memberItems().stream().map(JRuleItem::getType)
+                .collect(Collectors.toList());
+        Assertions.assertEquals(3, set.size());
+    }
+}

--- a/src/test/java/org/openhab/automation/jrule/rules/integration_test/ITJRulePersistence.java
+++ b/src/test/java/org/openhab/automation/jrule/rules/integration_test/ITJRulePersistence.java
@@ -257,7 +257,6 @@ public class ITJRulePersistence extends JRuleITBase {
                         givenFloat, expectedFloat, givenDeviation, deviation));
             }
         }
-        System.out.println(givenValue);
     }
 
     private void verifyPersistenceChangedSince(String itemName, int beforeSeconds, Object value) {

--- a/src/test/java/org/openhab/automation/jrule/rules/user/TestRules.java
+++ b/src/test/java/org/openhab/automation/jrule/rules/user/TestRules.java
@@ -239,7 +239,7 @@ public class TestRules extends JRule {
     @JRuleName(NAME_GET_MEMBERS_OF_GROUP)
     @JRuleWhenItemReceivedCommand(item = ITEM_GET_MEMBERS_OF_GROUP_SWITCH)
     public void getMembersOfGroup(JRuleItemEvent event) throws JRuleExecutionException {
-        Set<JRuleItem> members = JRuleSwitchGroupItem.forName(ITEM_SWITCH_GROUP).memberItemsGeneric();
+        Set<JRuleSwitchItem> members = JRuleSwitchGroupItem.forName(ITEM_SWITCH_GROUP).memberItems();
         if (members.size() != 2) {
             throw new JRuleExecutionException("expected 2 childs");
         }
@@ -250,14 +250,14 @@ public class TestRules extends JRule {
     @JRuleName(NAME_GET_MEMBERS_OF_NUMBER_GROUP)
     @JRuleWhenItemReceivedCommand(item = ITEM_GET_MEMBERS_OF_GROUP_SWITCH)
     public void getMembersOfNumberGroup(JRuleItemEvent event) throws JRuleExecutionException {
-        Set<JRuleItem> members = JRuleNumberGroupItem.forName(ITEM_NUMBER_GROUP).memberItemsGeneric();
+        Set<JRuleNumberItem> members = JRuleNumberGroupItem.forName(ITEM_NUMBER_GROUP).memberItems();
         if (members.size() != 2) {
             throw new JRuleExecutionException("expected 2 childs");
         }
         logInfo("contains members: {}", members.stream()
                 .map(jRuleItem -> jRuleItem.getName() + ":" + jRuleItem.getType()).collect(Collectors.joining(", ")));
 
-        Set<JRuleItem> recursiveMembers = JRuleNumberGroupItem.forName(ITEM_NUMBER_GROUP).memberItemsGeneric(true);
+        Set<JRuleNumberItem> recursiveMembers = JRuleNumberGroupItem.forName(ITEM_NUMBER_GROUP).memberItems(true);
         if (recursiveMembers.size() != 4) {
             throw new JRuleExecutionException("expected 4 childs");
         }

--- a/src/test/java/org/openhab/automation/jrule/rules/user/TestRules.java
+++ b/src/test/java/org/openhab/automation/jrule/rules/user/TestRules.java
@@ -239,7 +239,7 @@ public class TestRules extends JRule {
     @JRuleName(NAME_GET_MEMBERS_OF_GROUP)
     @JRuleWhenItemReceivedCommand(item = ITEM_GET_MEMBERS_OF_GROUP_SWITCH)
     public void getMembersOfGroup(JRuleItemEvent event) throws JRuleExecutionException {
-        Set<JRuleSwitchItem> members = JRuleSwitchGroupItem.forName(ITEM_SWITCH_GROUP).memberItems();
+        Set<? extends JRuleSwitchItem> members = JRuleSwitchGroupItem.forName(ITEM_SWITCH_GROUP).memberItems();
         if (members.size() != 2) {
             throw new JRuleExecutionException("expected 2 childs");
         }


### PR DESCRIPTION
returning set of memberItems should be type specific
to do something like this
```
JRuleItems.G_Presence_Outside_Camera.memberItems()
                .forEach(i -> i.sendCommand(JRuleOnOffValue.OFF)
        );
```
and not this
```
JRuleItems.G_Presence_Outside_Camera.memberItems()
                .stream().map(i -> (JRuleSwitchItem) i)
                .forEach(i -> i.sendCommand(JRuleOnOffValue.OFF)
        );
```