### PR TITLE
Fixed group item class generation

### DIFF
--- a/src/main/java/org/openhab/automation/jrule/items/JRuleItemClassGenerator.java
+++ b/src/main/java/org/openhab/automation/jrule/items/JRuleItemClassGenerator.java
@@ -85,7 +85,7 @@ public class JRuleItemClassGenerator extends JRuleAbstractClassGenerator {
         Map<String, Object> itemModel = new HashMap<>();
         itemModel.put("id", item.getUID());
         itemModel.put("name", item.getName());
-        String plainType = getPlainType(item);
+        String plainType = getPlainType(item.getType());
         itemModel.put("internalClass", "JRuleInternal" + plainType + "Item");
         itemModel.put("interfaceClass", "JRule" + plainType + "Item");
         itemModel.put("label", item.getLabel());
@@ -105,11 +105,11 @@ public class JRuleItemClassGenerator extends JRuleAbstractClassGenerator {
         return itemModel;
     }
 
-    private static String getPlainType(Item baseItem) {
-        if (baseItem.getType().contains(":")) {
+    private static String getPlainType(String itemType) {
+        if (itemType.contains(":")) {
             return "Quantity";
         }
-        return baseItem.getType();
+        return itemType;
     }
 
     private static String getPlainGroupType(GroupItem item, Item baseItem) {
@@ -120,11 +120,11 @@ public class JRuleItemClassGenerator extends JRuleAbstractClassGenerator {
             List<String> childItemTypes = item.getAllMembers().stream().map(Item::getType).distinct()
                     .collect(Collectors.toList());
             if (childItemTypes.size() == 1) {
-                return childItemTypes.get(0);
+                return getPlainType(childItemTypes.get(0));
             } else {
                 return ITEM_GROUP_TYPE_UNSPECIFIED;
             }
         }
-        return getPlainType(baseItem);
+        return getPlainType(baseItem.getType());
     }
 }

--- a/src/test/java/org/openhab/automation/jrule/items/JRuleItemTest.java
+++ b/src/test/java/org/openhab/automation/jrule/items/JRuleItemTest.java
@@ -13,8 +13,9 @@
 package org.openhab.automation.jrule.items;
 
 import java.lang.reflect.InvocationTargetException;
-import java.util.Map;
+import java.util.List;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -38,21 +39,21 @@ public class JRuleItemTest {
         MetadataRegistry metadataRegistry = Mockito.mock(MetadataRegistry.class);
         JRuleItemRegistry.setMetadataRegistry(metadataRegistry);
 
-        Map<Item, Class<? extends JRuleItem>> items = JRuleItemTestUtils.getAllDummyItems();
+        List<Pair<? extends Item, Class<? extends JRuleItem>>> items = JRuleItemTestUtils.getAllDummyItems();
 
         ItemRegistry itemRegistry = Mockito.mock(ItemRegistry.class);
         Mockito.when(itemRegistry.getItem(Mockito.anyString())).thenAnswer(invocationOnMock -> {
             Object itemName = invocationOnMock.getArgument(0);
-            return items.keySet().stream().filter(item -> item.getName().equals(itemName)).findFirst().orElseThrow();
+            return items.stream().filter(item -> item.getKey().getName().equals(itemName)).findFirst().orElseThrow();
         });
         JRuleEventHandler.get().setItemRegistry(itemRegistry);
 
-        items.forEach((ohItem, value) -> {
-            JRuleItem item = JRuleItem.forName(ohItem.getName());
+        items.forEach((entry) -> {
+            JRuleItem item = JRuleItem.forName(entry.getKey().getName());
             Assertions.assertNotNull(item);
-            Assertions.assertEquals(ohItem.getName(), item.getName());
-            Assertions.assertTrue(value.isAssignableFrom(item.getClass()),
-                    String.format("value '%s' is assignable from '%s'", value, item.getClass()));
+            Assertions.assertEquals(entry.getKey().getName(), item.getName());
+            Assertions.assertTrue(entry.getValue().isAssignableFrom(item.getClass()),
+                    String.format("value '%s' is assignable from '%s'", entry.getValue(), item.getClass()));
         });
     }
 }

--- a/src/test/java/org/openhab/automation/jrule/items/JRuleItemTest.java
+++ b/src/test/java/org/openhab/automation/jrule/items/JRuleItemTest.java
@@ -44,7 +44,8 @@ public class JRuleItemTest {
         ItemRegistry itemRegistry = Mockito.mock(ItemRegistry.class);
         Mockito.when(itemRegistry.getItem(Mockito.anyString())).thenAnswer(invocationOnMock -> {
             Object itemName = invocationOnMock.getArgument(0);
-            return items.stream().filter(item -> item.getKey().getName().equals(itemName)).findFirst().orElseThrow();
+            return items.stream().filter(item -> item.getKey().getName().equals(itemName)).findFirst()
+                    .map(e -> e.getKey()).orElseThrow();
         });
         JRuleEventHandler.get().setItemRegistry(itemRegistry);
 

--- a/src/test/java/org/openhab/automation/jrule/rules/user/TestReceiveCommands.java
+++ b/src/test/java/org/openhab/automation/jrule/rules/user/TestReceiveCommands.java
@@ -138,84 +138,84 @@ public class TestReceiveCommands extends JRule {
     @JRuleName(NAME_RECEIVE_SWITCH_UPDATE)
     @JRuleWhenItemReceivedUpdate(item = ITEM_SWITCH_EVENT)
     public void receiveSwitchUpdate(JRuleItemEvent event) {
-        logInfo("received: '{}', type: '{}'", event.getItem().getState(), event.getItem().getState().getClass());
+        logInfo("received: '{}', type: '{}'", event.getState(), event.getState().getClass());
         logInfo("received value: {}", event.getItem(JRuleSwitchItem.class).getStateAsOnOff());
     }
 
     @JRuleName(NAME_RECEIVE_NUMBER_UPDATE)
     @JRuleWhenItemReceivedUpdate(item = ITEM_NUMBER_EVENT)
     public void receiveNumberUpdate(JRuleItemEvent event) {
-        logInfo("received: '{}', type: '{}'", event.getItem().getState(), event.getItem().getState().getClass());
+        logInfo("received: '{}', type: '{}'", event.getState(), event.getState().getClass());
         logInfo("received value: {}", event.getItem(JRuleNumberItem.class).getStateAsDecimal().floatValue());
     }
 
     @JRuleName(NAME_RECEIVE_STRING_UPDATE)
     @JRuleWhenItemReceivedUpdate(item = ITEM_STRING_EVENT)
     public void receiveStringUpdate(JRuleItemEvent event) {
-        logInfo("received: '{}', type: '{}'", event.getItem().getState(), event.getItem().getState().getClass());
+        logInfo("received: '{}', type: '{}'", event.getState(), event.getState().getClass());
         logInfo("received value: {}", event.getItem(JRuleStringItem.class).getStateAsString());
     }
 
     @JRuleName(NAME_RECEIVE_DATETIME_UPDATE)
     @JRuleWhenItemReceivedUpdate(item = ITEM_DATETIME_EVENT)
     public void receiveDatetimeUpdate(JRuleItemEvent event) {
-        logInfo("received: '{}', type: '{}'", event.getItem().getState(), event.getItem().getState().getClass());
+        logInfo("received: '{}', type: '{}'", event.getState(), event.getState().getClass());
         logInfo("received value: {}", event.getItem(JRuleDateTimeItem.class).getStateAsDateTime().getValue());
     }
 
     @JRuleName(NAME_RECEIVE_PLAYER_UPDATE)
     @JRuleWhenItemReceivedUpdate(item = ITEM_PLAYER_EVENT)
     public void receivePlayerUpdate(JRuleItemEvent event) {
-        logInfo("received: '{}', type: '{}'", event.getItem().getState(), event.getItem().getState().getClass());
+        logInfo("received: '{}', type: '{}'", event.getState(), event.getState().getClass());
         logInfo("received value: {}", event.getItem(JRulePlayerItem.class).getStateAsPlayPause());
     }
 
     @JRuleName(NAME_RECEIVE_CONTACT_UPDATE)
     @JRuleWhenItemReceivedUpdate(item = ITEM_CONTACT_EVENT)
     public void receiveContactUpdate(JRuleItemEvent event) {
-        logInfo("received: '{}', type: '{}'", event.getItem().getState(), event.getItem().getState().getClass());
+        logInfo("received: '{}', type: '{}'", event.getState(), event.getState().getClass());
         logInfo("received value: {}", event.getItem(JRuleContactItem.class).getStateAsOpenClose());
     }
 
     @JRuleName(NAME_RECEIVE_IMAGE_UPDATE)
     @JRuleWhenItemReceivedUpdate(item = ITEM_IMAGE_EVENT)
     public void receiveImageUpdate(JRuleItemEvent event) {
-        logInfo("received: '{}', type: '{}'", event.getItem().getState(), event.getItem().getState().getClass());
+        logInfo("received: '{}', type: '{}'", event.getState(), event.getState().getClass());
         logInfo("received value: {}", event.getItem(JRuleImageItem.class).getStateAsRaw());
     }
 
     @JRuleName(NAME_RECEIVE_ROLLERSHUTTER_UPDATE)
     @JRuleWhenItemReceivedUpdate(item = ITEM_ROLLERSHUTTER_EVENT)
     public void receiveRollershutterUpdate(JRuleItemEvent event) {
-        logInfo("received: '{}', type: '{}'", event.getItem().getState(), event.getItem().getState().getClass());
+        logInfo("received: '{}', type: '{}'", event.getState(), event.getState().getClass());
         logInfo("received value: {}", event.getItem(JRuleRollershutterItem.class).getStateAsPercent().floatValue());
     }
 
     @JRuleName(NAME_RECEIVE_DIMMER_UPDATE)
     @JRuleWhenItemReceivedUpdate(item = ITEM_DIMMER_EVENT)
     public void receiveDimmerUpdate(JRuleItemEvent event) {
-        logInfo("received: '{}', type: '{}'", event.getItem().getState(), event.getItem().getState().getClass());
+        logInfo("received: '{}', type: '{}'", event.getState(), event.getState().getClass());
         logInfo("received value: {}", event.getItem(JRuleDimmerItem.class).getStateAsPercent().floatValue());
     }
 
     @JRuleName(NAME_RECEIVE_COLOR_UPDATE)
     @JRuleWhenItemReceivedUpdate(item = ITEM_COLOR_EVENT)
     public void receiveColorUpdate(JRuleItemEvent event) {
-        logInfo("received: '{}', type: '{}'", event.getItem().getState(), event.getItem().getState().getClass());
+        logInfo("received: '{}', type: '{}'", event.getState(), event.getState().getClass());
         logInfo("received value: {}", event.getItem(JRuleColorItem.class).getStateAsHsb());
     }
 
     @JRuleName(NAME_RECEIVE_LOCATION_UPDATE)
     @JRuleWhenItemReceivedUpdate(item = ITEM_LOCATION_EVENT)
     public void receiveLocationUpdate(JRuleItemEvent event) {
-        logInfo("received: '{}', type: '{}'", event.getItem().getState(), event.getItem().getState().getClass());
+        logInfo("received: '{}', type: '{}'", event.getState(), event.getState().getClass());
         logInfo("received value: {}", event.getItem(JRuleLocationItem.class).getStateAsPoint());
     }
 
     @JRuleName(NAME_RECEIVE_QUANTITY_UPDATE)
     @JRuleWhenItemReceivedUpdate(item = ITEM_QUANTITY_EVENT)
     public void receiveQuantityUpdate(JRuleItemEvent event) {
-        logInfo("received: '{}', type: '{}'", event.getItem().getState(), event.getItem().getState().getClass());
+        logInfo("received: '{}', type: '{}'", event.getState(), event.getState().getClass());
         logInfo("received value: {}", event.getItem(JRuleQuantityItem.class).getStateAsDecimal().floatValue());
     }
 }

--- a/src/test/java/org/openhab/automation/jrule/rules/user/TestRules.java
+++ b/src/test/java/org/openhab/automation/jrule/rules/user/TestRules.java
@@ -154,25 +154,25 @@ public class TestRules extends JRule {
     @JRuleName(NAME_SWITCH_ITEM_RECEIVED_ANY_UPDATE)
     @JRuleWhenItemReceivedUpdate(item = ITEM_RECEIVING_COMMAND_SWITCH)
     public void switchItemReceivedUpdate(JRuleItemEvent event) {
-        logInfo("received update: {}", event.getItem().getState().stringValue());
+        logInfo("received update: {}", event.getState().stringValue());
     }
 
     @JRuleName(NAME_SWITCH_ITEM_RECEIVED_ON_UPDATE)
     @JRuleWhenItemReceivedUpdate(item = ITEM_RECEIVING_COMMAND_SWITCH, state = JRuleSwitchItem.ON)
     public void switchReceivedOnUpdate(JRuleItemEvent event) {
-        logInfo("received update: {}", event.getItem().getState().stringValue());
+        logInfo("received update: {}", event.getState().stringValue());
     }
 
     @JRuleName(NAME_SWITCH_ITEM_CHANGED)
     @JRuleWhenItemChange(item = ITEM_RECEIVING_COMMAND_SWITCH)
     public void switchItemChanged(JRuleItemEvent event) {
-        logInfo("changed from '{}' to '{}'", event.getOldState(), event.getItem().getState());
+        logInfo("changed from '{}' to '{}'", event.getOldState(), event.getState());
     }
 
     @JRuleName(NAME_SWITCH_ITEM_CHANGED_TO_ON)
     @JRuleWhenItemChange(item = ITEM_RECEIVING_COMMAND_SWITCH, from = JRuleSwitchItem.OFF, to = JRuleSwitchItem.ON)
     public void switchReceivedChangedToOn(JRuleItemEvent event) {
-        logInfo("changed: {}", event.getItem().getState().stringValue());
+        logInfo("changed: {}", event.getState().stringValue());
     }
 
     @JRuleName(NAME_INVOKE_MQTT_ACTION)
@@ -228,7 +228,7 @@ public class TestRules extends JRule {
     @JRuleName(NAME_PRECONDITION_LTE_AND_GTE_FOR_NUMBER)
     @JRuleWhenItemChange(item = ITEM_NUMBER_CONDITION, condition = @JRuleCondition(lte = 20, gte = 18))
     public synchronized void conditionLteAndGteForNumber(JRuleItemEvent event) {
-        logInfo("trigger when between 18 and 20, current: {}", event.getItem().getState().stringValue());
+        logInfo("trigger when between 18 and 20, current: {}", event.getState().stringValue());
     }
 
     @JRuleName(NAME_CRON_EVERY_5_SEC)

--- a/src/test/java/org/openhab/automation/jrule/test_utils/JRuleItemTestUtils.java
+++ b/src/test/java/org/openhab/automation/jrule/test_utils/JRuleItemTestUtils.java
@@ -75,7 +75,7 @@ public class JRuleItemTestUtils {
 
         GroupItem groupItemNoBaseWithMember = createGroupItem(null, new QuantityType<>(340, Units.BAR));
         groupItemNoBaseWithMember.addMember(createItem(NumberItem.class, new QuantityType<>(340, Units.BAR)));
-        items.add(Pair.of(groupItemNoBaseWithMember, JRuleQuantityGroupItem.class));
+        items.add(Pair.of(groupItemNoBaseWithMember, JRuleUnspecifiedGroupItem.class));
 
         items.add(Pair.of(createGroupItem(RollershutterItem.class, new PercentType(22)),
                 JRuleRollershutterGroupItem.class));

--- a/src/test/java/org/openhab/automation/jrule/test_utils/JRuleItemTestUtils.java
+++ b/src/test/java/org/openhab/automation/jrule/test_utils/JRuleItemTestUtils.java
@@ -14,11 +14,11 @@ package org.openhab.automation.jrule.test_utils;
 
 import java.lang.reflect.InvocationTargetException;
 import java.time.ZonedDateTime;
-import java.util.HashMap;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 
-import org.jetbrains.annotations.NotNull;
+import org.apache.commons.lang3.tuple.Pair;
 import org.openhab.automation.jrule.items.*;
 import org.openhab.core.items.GenericItem;
 import org.openhab.core.items.GroupItem;
@@ -34,46 +34,59 @@ import org.openhab.core.types.State;
  * @author Robert Delbrück - Initial contribution
  */
 public class JRuleItemTestUtils {
-    @NotNull
-    public static Map<Item, Class<? extends JRuleItem>> getAllDummyItems()
+    private static AtomicInteger counter = new AtomicInteger(0);
+
+    public static List<Pair<? extends Item, Class<? extends JRuleItem>>> getAllDummyItems()
             throws NoSuchMethodException, InvocationTargetException, InstantiationException, IllegalAccessException {
-        Map<Item, Class<? extends JRuleItem>> items = new HashMap<>();
+        List<Pair<? extends Item, Class<? extends JRuleItem>>> items = new ArrayList<>();
 
-        items.put(createItem(StringItem.class, new StringType("abc")), JRuleStringItem.class);
-        items.put(createItem(ColorItem.class, new HSBType(new DecimalType(1), new PercentType(2), new PercentType(3))),
-                JRuleColorItem.class);
-        items.put(createItem(ContactItem.class, OpenClosedType.OPEN), JRuleContactItem.class);
-        items.put(createItem(DateTimeItem.class, new DateTimeType(ZonedDateTime.now())), JRuleDateTimeItem.class);
-        items.put(createItem(DimmerItem.class, new PercentType(50)), JRuleDimmerItem.class);
-        items.put(createItem(PlayerItem.class, PlayPauseType.PAUSE), JRulePlayerItem.class);
-        items.put(createItem(SwitchItem.class, OnOffType.OFF), JRuleSwitchItem.class);
-        items.put(createItem(NumberItem.class, new DecimalType(340)), JRuleNumberItem.class);
-        items.put(createItem(NumberItem.class, new QuantityType<>(340, Units.BAR)), JRuleQuantityItem.class);
-        items.put(createItem(RollershutterItem.class, new PercentType(22)), JRuleRollershutterItem.class);
-        items.put(createItem(LocationItem.class, new PointType(new DecimalType(22.22), new DecimalType(54.12))),
-                JRuleLocationItem.class);
-        items.put(createItem(CallItem.class, new StringListType(List.of("+4930123456"))), JRuleCallItem.class);
-        items.put(createItem(ImageItem.class, new RawType(new byte[0], "jpeg")), JRuleImageItem.class);
+        items.add(Pair.of(createItem(StringItem.class, new StringType("abc")), JRuleStringItem.class));
+        items.add(Pair.of(
+                createItem(ColorItem.class, new HSBType(new DecimalType(1), new PercentType(2), new PercentType(3))),
+                JRuleColorItem.class));
+        items.add(Pair.of(createItem(ContactItem.class, OpenClosedType.OPEN), JRuleContactItem.class));
+        items.add(Pair.of(createItem(DateTimeItem.class, new DateTimeType(ZonedDateTime.now())),
+                JRuleDateTimeItem.class));
+        items.add(Pair.of(createItem(DimmerItem.class, new PercentType(50)), JRuleDimmerItem.class));
+        items.add(Pair.of(createItem(PlayerItem.class, PlayPauseType.PAUSE), JRulePlayerItem.class));
+        items.add(Pair.of(createItem(SwitchItem.class, OnOffType.OFF), JRuleSwitchItem.class));
+        items.add(Pair.of(createItem(NumberItem.class, new DecimalType(340)), JRuleNumberItem.class));
+        items.add(Pair.of(createItem(NumberItem.class, new QuantityType<>(340, Units.BAR)), JRuleQuantityItem.class));
+        items.add(Pair.of(createItem(RollershutterItem.class, new PercentType(22)), JRuleRollershutterItem.class));
+        items.add(Pair.of(createItem(LocationItem.class, new PointType(new DecimalType(22.22), new DecimalType(54.12))),
+                JRuleLocationItem.class));
+        items.add(Pair.of(createItem(CallItem.class, new StringListType(List.of("+4930123456"))), JRuleCallItem.class));
+        items.add(Pair.of(createItem(ImageItem.class, new RawType(new byte[0], "jpeg")), JRuleImageItem.class));
 
-        items.put(createGroupItem(StringItem.class, new StringType("abc")), JRuleStringGroupItem.class);
-        items.put(
+        items.add(Pair.of(createGroupItem(StringItem.class, new StringType("abc")), JRuleStringGroupItem.class));
+        items.add(Pair.of(
                 createGroupItem(ColorItem.class,
                         new HSBType(new DecimalType(1), new PercentType(2), new PercentType(3))),
-                JRuleColorGroupItem.class);
-        items.put(createGroupItem(ContactItem.class, OpenClosedType.OPEN), JRuleContactGroupItem.class);
-        items.put(createGroupItem(DateTimeItem.class, new DateTimeType(ZonedDateTime.now())), JRuleDateTimeItem.class);
-        items.put(createGroupItem(DimmerItem.class, new PercentType(50)), JRuleDimmerGroupItem.class);
-        items.put(createGroupItem(PlayerItem.class, PlayPauseType.PAUSE), JRulePlayerGroupItem.class);
-        items.put(createGroupItem(SwitchItem.class, OnOffType.OFF), JRuleSwitchGroupItem.class);
-        items.put(createGroupItem(NumberItem.class, new DecimalType(340)), JRuleNumberGroupItem.class);
-        items.put(createGroupItem(NumberItem.class, new QuantityType<>(340, Units.BAR)), JRuleQuantityGroupItem.class);
-        items.put(createGroupItem(RollershutterItem.class, new PercentType(22)), JRuleRollershutterGroupItem.class);
-        items.put(createGroupItem(LocationItem.class, new PointType(new DecimalType(22.22), new DecimalType(54.12))),
-                JRuleLocationGroupItem.class);
-        items.put(createGroupItem(CallItem.class, new StringListType(List.of("+4930123456"))),
-                JRuleCallGroupItem.class);
-        items.put(createGroupItem(ImageItem.class, new RawType(new byte[0], "jpeg")), JRuleImageGroupItem.class);
-        items.put(createGroupItem(null, null), JRuleUnspecifiedGroupItem.class);
+                JRuleColorGroupItem.class));
+        items.add(Pair.of(createGroupItem(ContactItem.class, OpenClosedType.OPEN), JRuleContactGroupItem.class));
+        items.add(Pair.of(createGroupItem(DateTimeItem.class, new DateTimeType(ZonedDateTime.now())),
+                JRuleDateTimeItem.class));
+        items.add(Pair.of(createGroupItem(DimmerItem.class, new PercentType(50)), JRuleDimmerGroupItem.class));
+        items.add(Pair.of(createGroupItem(PlayerItem.class, PlayPauseType.PAUSE), JRulePlayerGroupItem.class));
+        items.add(Pair.of(createGroupItem(SwitchItem.class, OnOffType.OFF), JRuleSwitchGroupItem.class));
+        items.add(Pair.of(createGroupItem(NumberItem.class, new DecimalType(340)), JRuleNumberGroupItem.class));
+        items.add(Pair.of(createGroupItem(NumberItem.class, new QuantityType<>(340, Units.BAR)),
+                JRuleQuantityGroupItem.class));
+
+        GroupItem groupItemNoBaseWithMember = createGroupItem(null, new QuantityType<>(340, Units.BAR));
+        groupItemNoBaseWithMember.addMember(createItem(NumberItem.class, new QuantityType<>(340, Units.BAR)));
+        items.add(Pair.of(groupItemNoBaseWithMember, JRuleQuantityGroupItem.class));
+
+        items.add(Pair.of(createGroupItem(RollershutterItem.class, new PercentType(22)),
+                JRuleRollershutterGroupItem.class));
+        items.add(Pair.of(
+                createGroupItem(LocationItem.class, new PointType(new DecimalType(22.22), new DecimalType(54.12))),
+                JRuleLocationGroupItem.class));
+        items.add(Pair.of(createGroupItem(CallItem.class, new StringListType(List.of("+4930123456"))),
+                JRuleCallGroupItem.class));
+        items.add(
+                Pair.of(createGroupItem(ImageItem.class, new RawType(new byte[0], "jpeg")), JRuleImageGroupItem.class));
+        items.add(Pair.of(createGroupItem(null, null), JRuleUnspecifiedGroupItem.class));
         return items;
     }
 
@@ -86,7 +99,10 @@ public class JRuleItemTestUtils {
         } else {
             name = (clazz != null ? clazz.getSimpleName() : "");
         }
-        GroupItem groupItem = new GroupItem(name + "Group", baseItem);
+        GroupItem groupItem = new GroupItem(name + "Group" + counter.incrementAndGet(), baseItem);
+        if (baseItem != null) {
+            groupItem.addMember(baseItem);
+        }
         groupItem.setState(initialState);
         return groupItem;
     }


### PR DESCRIPTION
For a group of Number:Temperature items, the group is generated incorrectly and the JRuleItems class cannot be compiled.

.items file:
```
Group gTemperature

Number:Temperature Item_1 (gTemperature)
Number:Temperature Item_2 (gTemperature)
```

generated JRuleItems class:
```
public static JRuleNumber:TemperatureGroupItem gTemperature;

gTemperature = JRuleItemRegistry.get("gTemperature", JRuleInternalNumber:TemperatureGroupItem.class);
```

This patch fixed it for me