### PR TITLE
Fix for thing actions without @ActionInput

### DIFF
--- a/src/main/java/org/openhab/automation/jrule/actions/JRuleActionClassGenerator.java
+++ b/src/main/java/org/openhab/automation/jrule/actions/JRuleActionClassGenerator.java
@@ -162,14 +162,6 @@ public class JRuleActionClassGenerator extends JRuleAbstractClassGenerator {
                     .filter(method -> method.getAnnotation(RuleAction.class) != null).collect(Collectors.toSet())
 
                     .forEach(method -> {
-
-                        /*
-                         * .filter(method -> method.getReturnType().isPrimitive()
-                         * || "org.openhab.core.library.types".equals(method.getReturnType().getPackageName())
-                         * || method.getReturnType().getPackageName().startsWith("java."))
-                         * 
-                         */
-
                         Map<Object, Object> methodMap = new HashMap<>();
                         methodMap.put("name", method.getName());
 

--- a/src/main/java/org/openhab/automation/jrule/actions/JRuleActionClassGenerator.java
+++ b/src/main/java/org/openhab/automation/jrule/actions/JRuleActionClassGenerator.java
@@ -21,7 +21,6 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
@@ -183,8 +182,7 @@ public class JRuleActionClassGenerator extends JRuleAbstractClassGenerator {
                                 arg.put("type", parameterType.getTypeName());
                                 arg.put("reflectionType", ClassUtils.primitiveToWrapper(parameter.getType())
                                         .getTypeName().replaceFirst("java.lang.", ""));
-                                arg.put("name", Objects.requireNonNull(parameter.getAnnotation(ActionInput.class),
-                                        "ActionInput not set on action method parameter").name());
+                                arg.put("name", parameter.getAnnotation(ActionInput.class).name());
                                 args.add(arg);
                             }
                         });

--- a/src/main/java/org/openhab/automation/jrule/actions/JRuleActionClassGenerator.java
+++ b/src/main/java/org/openhab/automation/jrule/actions/JRuleActionClassGenerator.java
@@ -161,7 +161,8 @@ public class JRuleActionClassGenerator extends JRuleAbstractClassGenerator {
             Arrays.stream(thingActionsClass.getDeclaredMethods())
                     .filter(method -> method.getAnnotation(RuleAction.class) != null)
                     .filter(method -> method.getReturnType().isPrimitive()
-                            || "java.lang".equals(method.getReturnType().getPackageName()))
+                            || "java.lang".equals(method.getReturnType().getPackageName())
+                            || "org.openhab.core.library.types".equals(method.getReturnType().getPackageName()))
                     .collect(Collectors.toSet())
 
                     .forEach(method -> {

--- a/src/main/java/org/openhab/automation/jrule/actions/JRuleActionClassGenerator.java
+++ b/src/main/java/org/openhab/automation/jrule/actions/JRuleActionClassGenerator.java
@@ -161,8 +161,8 @@ public class JRuleActionClassGenerator extends JRuleAbstractClassGenerator {
             Arrays.stream(thingActionsClass.getDeclaredMethods())
                     .filter(method -> method.getAnnotation(RuleAction.class) != null)
                     .filter(method -> method.getReturnType().isPrimitive()
-                            || "java.lang".equals(method.getReturnType().getPackageName())
-                            || "org.openhab.core.library.types".equals(method.getReturnType().getPackageName()))
+                            || "org.openhab.core.library.types".equals(method.getReturnType().getPackageName())
+                            || method.getReturnType().getPackageName().startsWith("java."))
                     .collect(Collectors.toSet())
 
                     .forEach(method -> {

--- a/src/main/java/org/openhab/automation/jrule/actions/JRuleActionClassGenerator.java
+++ b/src/main/java/org/openhab/automation/jrule/actions/JRuleActionClassGenerator.java
@@ -159,7 +159,11 @@ public class JRuleActionClassGenerator extends JRuleAbstractClassGenerator {
             freemarkerModel.put("imports", imports);
 
             Arrays.stream(thingActionsClass.getDeclaredMethods())
-                    .filter(method -> method.getAnnotation(RuleAction.class) != null).collect(Collectors.toSet())
+                    .filter(method -> method.getAnnotation(RuleAction.class) != null)
+                    .filter(method -> method.getReturnType().isPrimitive()
+                            || method.getReturnType().getPackageName().equals("java.lang"))
+                    .collect(Collectors.toSet())
+
                     .forEach(method -> {
                         Map<Object, Object> methodMap = new HashMap<>();
                         methodMap.put("name", method.getName());

--- a/src/main/java/org/openhab/automation/jrule/actions/JRuleActionClassGenerator.java
+++ b/src/main/java/org/openhab/automation/jrule/actions/JRuleActionClassGenerator.java
@@ -161,7 +161,7 @@ public class JRuleActionClassGenerator extends JRuleAbstractClassGenerator {
             Arrays.stream(thingActionsClass.getDeclaredMethods())
                     .filter(method -> method.getAnnotation(RuleAction.class) != null)
                     .filter(method -> method.getReturnType().isPrimitive()
-                            || method.getReturnType().getPackageName().equals("java.lang"))
+                            || "java.lang".equals(method.getReturnType().getPackageName()))
                     .collect(Collectors.toSet())
 
                     .forEach(method -> {

--- a/src/main/resources/templates/actions/Action.ftlh
+++ b/src/main/resources/templates/actions/Action.ftlh
@@ -4,17 +4,15 @@ package ${action.package};
 
 import org.openhab.automation.jrule.actions.${action.parentClass};
 import java.util.Objects;
-<#list action.methods as method>
-<#if method.import == true>
-import ${method.returnType};
-</#if>
+<#list action.imports as import>
+    import ${import};
 </#list>
 
 <#include "ActionJavadoc.ftlh">
 public class ${action.class} extends ${action.parentClass} {
 <#include "ActionConstructor.ftlh">
 <#list action.methods as method>
- <#include "ActionMethod.ftlh">
+    <#include "ActionMethod.ftlh">
 
 
 </#list>

--- a/src/test/java/org/openhab/automation/jrule/internal/codegenerator/JRuleActionClassGeneratorTest.java
+++ b/src/test/java/org/openhab/automation/jrule/internal/codegenerator/JRuleActionClassGeneratorTest.java
@@ -12,6 +12,8 @@
  */
 package org.openhab.automation.jrule.internal.codegenerator;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
@@ -29,7 +31,6 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -40,6 +41,7 @@ import org.openhab.automation.jrule.actions.JRuleActionClassGenerator;
 import org.openhab.automation.jrule.internal.JRuleConfig;
 import org.openhab.automation.jrule.internal.compiler.JRuleCompiler;
 import org.openhab.automation.jrule.internal.thingaction.MyThingActions;
+import org.openhab.automation.jrule.rules.JRule;
 import org.openhab.core.library.types.StringType;
 import org.openhab.core.magic.binding.handler.MagicActionModuleThingHandler;
 import org.openhab.core.model.script.internal.engine.action.ThingActionService;
@@ -143,9 +145,19 @@ public class JRuleActionClassGeneratorTest {
         Object jRuleActions = aClass.getConstructor().newInstance();
         Field mybindingThingtypeId1 = aClass.getDeclaredField("mybindingThingtypeId1");
         Object action = mybindingThingtypeId1.get(jRuleActions);
+
+        // Verify methods exists
         Method doSomethingAbstract = action.getClass().getDeclaredMethod("doSomethingAbstract", Command.class);
         Object res = doSomethingAbstract.invoke(action, new StringType("blub"));
-        Assertions.assertEquals(10, res);
+        assertEquals(10, res);
+
+        // Verify method with unsupported types are mapped to Object
+        Method returnObjectOnUnsupportedClass = action.getClass().getDeclaredMethod("returnObjectOnUnsupportedClass",
+                Object.class);
+        assertNotNull(returnObjectOnUnsupportedClass);
+        assertEquals(Object.class, returnObjectOnUnsupportedClass.getReturnType());
+        JRule returnObject = (JRule) returnObjectOnUnsupportedClass.invoke(action, new JRule());
+        assertNotNull(returnObject);
     }
 
     private void generateAndCompile(Thing thing) {

--- a/src/test/java/org/openhab/automation/jrule/internal/thingaction/MyThingActions.java
+++ b/src/test/java/org/openhab/automation/jrule/internal/thingaction/MyThingActions.java
@@ -42,7 +42,7 @@ public class MyThingActions implements ThingActions {
     }
 
     @RuleAction(label = "noActionInput")
-    public int noActionInput(@ActionInput(name = "value") String value, @ActionInput(name = "blabla") Float blabla) {
+    public int noActionInput(String value) {
         return 0;
     }
 

--- a/src/test/java/org/openhab/automation/jrule/internal/thingaction/MyThingActions.java
+++ b/src/test/java/org/openhab/automation/jrule/internal/thingaction/MyThingActions.java
@@ -41,6 +41,11 @@ public class MyThingActions implements ThingActions {
         return 0;
     }
 
+    @RuleAction(label = "noActionInput")
+    public int noActionInput(@ActionInput(name = "value") String value, @ActionInput(name = "blabla") Float blabla) {
+        return 0;
+    }
+
     @RuleAction(label = "doSomethingAbstract")
     public int doSomethingAbstract(@ActionInput(name = "value") Command value) {
         return 10;

--- a/src/test/java/org/openhab/automation/jrule/internal/thingaction/MyThingActions.java
+++ b/src/test/java/org/openhab/automation/jrule/internal/thingaction/MyThingActions.java
@@ -13,6 +13,7 @@
 package org.openhab.automation.jrule.internal.thingaction;
 
 import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.automation.jrule.rules.JRule;
 import org.openhab.core.automation.annotation.ActionInput;
 import org.openhab.core.automation.annotation.RuleAction;
 import org.openhab.core.library.types.QuantityType;
@@ -58,5 +59,10 @@ public class MyThingActions implements ThingActions {
     @Override
     public @Nullable ThingHandler getThingHandler() {
         return null;
+    }
+
+    @RuleAction(label = "returnObjectOnUnsupportedClass")
+    public JRule returnObjectOnUnsupportedClass(@ActionInput(name = "value") JRule value) {
+        return value;
     }
 }


### PR DESCRIPTION
Partial fix for #142 .

Missing: Compilation of generated code relies only on openhab-core and jrule jar, and due to https://github.com/openhab/openhab-addons/blob/8e902f63243a11e2dd9898fade150312184aa23c/bundles/org.openhab.binding.dbquery/src/main/java/org/openhab/binding/dbquery/action/DBQueryActions.java#L49 returning `ActionQueryResult`from dbquery https://github.com/openhab/openhab-addons/blob/8e902f63243a11e2dd9898fade150312184aa23c/bundles/org.openhab.binding.dbquery/src/main/java/org/openhab/binding/dbquery/action/ActionQueryResult.java#L13 compilation fails.

Not sure what to do here; either include all openhab jars as classpath (including addons) - or replicate class dynamically?
@querdenker2k  WDYT?