### PR TITLE
Store jar file as build artifact

### DIFF
--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -14,7 +14,8 @@ jobs:
     - name: Build with Maven
       run: mvn --batch-mode --update-snapshots install
     - run: mkdir staging && cp target/org.openhab.automation.jrule*SNAPSHOT.jar staging
+    - run: echo "JRule-jar-zipped_branch_$GITHUB_REF_NAME"
     - uses: actions/upload-artifact@v3
       with:
-        name: JRule-jar-zipped_branch_${{ env.GITHUB_REF_NAME }}
+        name: JRule-jar-zipped_branch_${{ github.ref_name }}
         path: staging

--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -17,5 +17,5 @@ jobs:
     - run: echo "JRule-jar-zipped_branch_$GITHUB_REF_NAME"
     - uses: actions/upload-artifact@v3
       with:
-        name: JRule-jar-zipped_branch_${{ github.ref_name }}
+        name: JRule-jar-zipped_branch_${{ github.run_id }}
         path: staging

--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -1,14 +1,19 @@
 name: Java CI
-on: [push,pull_request]
+on: [ push,pull_request ]
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - name: Set up JDK 11
-        uses: actions/setup-java@v3
-        with:
-          java-version: '11'
-          distribution: 'adopt'
-      - name: Build with Maven
-        run: mvn clean install
+    - uses: actions/checkout@v3
+    - name: Set up JDK 11
+      uses: actions/setup-java@v3
+      with:
+        java-version: '11'
+        distribution: 'adopt'
+    - name: Build with Maven
+      run: mvn clean install
+    - run: mkdir staging && cp target/*.jar staging
+    - uses: actions/upload-artifact@v3
+      with:
+        name: Package
+        path: staging

--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -15,5 +15,5 @@ jobs:
     - run: mkdir staging && cp target/org.openhab.automation.jrule*SNAPSHOT.jar staging
     - uses: actions/upload-artifact@v3
       with:
-        name: JRule-jar-zipped
+        name: JRule-jar-zipped_branch_$GITHUB_REF_NAME
         path: staging

--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -12,9 +12,9 @@ jobs:
         distribution: 'adopt'
         cache: 'maven'
     - name: Build with Maven
-      run: mvn clean install
+      run: mvn --batch-mode --update-snapshots install
     - run: mkdir staging && cp target/org.openhab.automation.jrule*SNAPSHOT.jar staging
     - uses: actions/upload-artifact@v3
       with:
-        name: JRule-jar-zipped_branch_$GITHUB_REF_NAME
+        name: JRule-jar-zipped_branch_${{ env.GITHUB_REF_NAME }}
         path: staging

--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -12,7 +12,7 @@ jobs:
         distribution: 'adopt'
     - name: Build with Maven
       run: mvn clean install
-    - run: mkdir staging && cp target/*.jar staging
+    - run: mkdir staging && cp target/org.openhab.automation.jrule*SNAPSHOT.jar staging
     - uses: actions/upload-artifact@v3
       with:
         name: Package

--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -14,8 +14,7 @@ jobs:
     - name: Build with Maven
       run: mvn --batch-mode --update-snapshots install
     - run: mkdir staging && cp target/org.openhab.automation.jrule*SNAPSHOT.jar staging
-    - run: echo "JRule-jar-zipped_branch_$GITHUB_REF_NAME"
     - uses: actions/upload-artifact@v3
       with:
-        name: JRule-jar-zipped_branch_${{ github.run_id }}
+        name: JRule-jar-zipped_build_${{ github.run_id }}
         path: staging

--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -15,5 +15,5 @@ jobs:
     - run: mkdir staging && cp target/org.openhab.automation.jrule*SNAPSHOT.jar staging
     - uses: actions/upload-artifact@v3
       with:
-        name: Package
+        name: JRule-jar-zipped
         path: staging

--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -10,6 +10,7 @@ jobs:
       with:
         java-version: '11'
         distribution: 'adopt'
+        cache: 'maven'
     - name: Build with Maven
       run: mvn clean install
     - run: mkdir staging && cp target/org.openhab.automation.jrule*SNAPSHOT.jar staging


### PR DESCRIPTION
2 things: 

* enable maven cache for faster builds.
* store each build as an artifact on the build. Makes it easier to publish test artifacts to reporters