### PR TITLE
Only consider methods declared in rule class, not inherited methods

### DIFF
--- a/src/main/java/org/openhab/automation/jrule/internal/engine/JRuleEngine.java
+++ b/src/main/java/org/openhab/automation/jrule/internal/engine/JRuleEngine.java
@@ -129,6 +129,7 @@ public class JRuleEngine implements PropertyChangeListener {
         logDebug("Adding rule: {}, enabled: {}", jRule, enableRule);
         ruleLoadingStatistics.addRuleClass();
         Arrays.stream(jRule.getClass().getDeclaredMethods()).filter(method -> !method.getName().startsWith("lambda$"))
+                .filter(method -> method.getDeclaringClass().equals(jRule.getClass())) // Skip inherited methods
                 .forEach(method -> this.add(method, jRule, enableRule));
     }
 


### PR DESCRIPTION
Reduces uninteresting output with debug logging. 