### PR TITLE
Send updates/commands to group items itself, not just members

### DIFF
--- a/src/main/java/org/openhab/automation/jrule/items/JRuleCallGroupItem.java
+++ b/src/main/java/org/openhab/automation/jrule/items/JRuleCallGroupItem.java
@@ -46,6 +46,7 @@ public interface JRuleCallGroupItem extends JRuleCallItem, JRuleGroupItem<JRuleC
     }
 
     default void postUpdate(JRuleStringListValue state) {
+        JRuleEventHandler.get().postUpdate(getName(), state);
         JRuleEventHandler.get().getGroupMemberItems(getName(), false).forEach(i -> i.postUncheckedUpdate(state));
     }
 }

--- a/src/main/java/org/openhab/automation/jrule/items/JRuleColorGroupItem.java
+++ b/src/main/java/org/openhab/automation/jrule/items/JRuleColorGroupItem.java
@@ -46,10 +46,12 @@ public interface JRuleColorGroupItem extends JRuleColorItem, JRuleDimmerGroupIte
     }
 
     default void sendCommand(JRuleHsbValue command) {
+        JRuleEventHandler.get().sendCommand(getName(), command);
         JRuleEventHandler.get().getGroupMemberItems(getName(), false).forEach(i -> i.sendUncheckedCommand(command));
     }
 
     default void postUpdate(JRuleHsbValue state) {
+        JRuleEventHandler.get().postUpdate(getName(), state);
         JRuleEventHandler.get().getGroupMemberItems(getName(), false).forEach(i -> i.postUncheckedUpdate(state));
     }
 }

--- a/src/main/java/org/openhab/automation/jrule/items/JRuleContactGroupItem.java
+++ b/src/main/java/org/openhab/automation/jrule/items/JRuleContactGroupItem.java
@@ -46,6 +46,7 @@ public interface JRuleContactGroupItem extends JRuleContactItem, JRuleGroupItem<
     }
 
     default void postUpdate(JRuleOpenClosedValue state) {
+        JRuleEventHandler.get().postUpdate(getName(), state);
         JRuleEventHandler.get().getGroupMemberItems(getName(), false).forEach(i -> i.postUncheckedUpdate(state));
     }
 }

--- a/src/main/java/org/openhab/automation/jrule/items/JRuleDateTimeGroupItem.java
+++ b/src/main/java/org/openhab/automation/jrule/items/JRuleDateTimeGroupItem.java
@@ -48,29 +48,35 @@ public interface JRuleDateTimeGroupItem extends JRuleDateTimeItem, JRuleGroupIte
     }
 
     default void sendCommand(JRuleDateTimeValue command) {
+        JRuleEventHandler.get().sendCommand(getName(), command);
         JRuleEventHandler.get().getGroupMemberItems(getName(), false).forEach(i -> i.sendUncheckedCommand(command));
     }
 
     default void postUpdate(JRuleDateTimeValue state) {
+        JRuleEventHandler.get().postUpdate(getName(), state);
         JRuleEventHandler.get().getGroupMemberItems(getName(), false).forEach(i -> i.postUncheckedUpdate(state));
     }
 
     default void sendCommand(Date command) {
+        JRuleEventHandler.get().sendCommand(getName(), new JRuleDateTimeValue(command));
         JRuleEventHandler.get().getGroupMemberItems(getName(), false)
                 .forEach(i -> i.sendUncheckedCommand(new JRuleDateTimeValue(command)));
     }
 
     default void sendCommand(ZonedDateTime command) {
+        JRuleEventHandler.get().sendCommand(getName(), new JRuleDateTimeValue(command));
         JRuleEventHandler.get().getGroupMemberItems(getName(), false)
                 .forEach(i -> i.sendUncheckedCommand(new JRuleDateTimeValue(command)));
     }
 
     default void postUpdate(Date state) {
+        JRuleEventHandler.get().postUpdate(getName(), new JRuleDateTimeValue(state));
         JRuleEventHandler.get().getGroupMemberItems(getName(), false)
                 .forEach(i -> i.postUncheckedUpdate(new JRuleDateTimeValue(state)));
     }
 
     default void postUpdate(ZonedDateTime state) {
+        JRuleEventHandler.get().postUpdate(getName(), new JRuleDateTimeValue(state));
         JRuleEventHandler.get().getGroupMemberItems(getName(), false)
                 .forEach(i -> i.postUncheckedUpdate(new JRuleDateTimeValue(state)));
     }

--- a/src/main/java/org/openhab/automation/jrule/items/JRuleDimmerGroupItem.java
+++ b/src/main/java/org/openhab/automation/jrule/items/JRuleDimmerGroupItem.java
@@ -47,27 +47,33 @@ public interface JRuleDimmerGroupItem extends JRuleDimmerItem, JRuleSwitchGroupI
     }
 
     default void sendCommand(JRulePercentValue command) {
+        JRuleEventHandler.get().sendCommand(getName(), command);
         JRuleEventHandler.get().getGroupMemberItems(getName(), false).forEach(i -> i.sendUncheckedCommand(command));
     }
 
     default void postUpdate(JRulePercentValue state) {
+        JRuleEventHandler.get().postUpdate(getName(), state);
         JRuleEventHandler.get().getGroupMemberItems(getName(), false).forEach(i -> i.postUncheckedUpdate(state));
     }
 
     default void sendCommand(int command) {
+        JRuleEventHandler.get().sendCommand(getName(), new JRulePercentValue(command));
         JRuleEventHandler.get().getGroupMemberItems(getName(), false)
                 .forEach(i -> i.sendUncheckedCommand(new JRulePercentValue(command)));
     }
 
     default void sendCommand(JRuleIncreaseDecreaseValue command) {
+        JRuleEventHandler.get().sendCommand(getName(), command);
         JRuleEventHandler.get().getGroupMemberItems(getName(), false).forEach(i -> i.sendUncheckedCommand(command));
     }
 
     default void postUpdate(JRuleIncreaseDecreaseValue state) {
+        JRuleEventHandler.get().postUpdate(getName(), state);
         JRuleEventHandler.get().getGroupMemberItems(getName(), false).forEach(i -> i.postUncheckedUpdate(state));
     }
 
     default void postUpdate(int state) {
+        JRuleEventHandler.get().postUpdate(getName(), new JRulePercentValue(state));
         JRuleEventHandler.get().getGroupMemberItems(getName(), false)
                 .forEach(i -> i.postUncheckedUpdate(new JRulePercentValue(state)));
     }

--- a/src/main/java/org/openhab/automation/jrule/items/JRuleGroupItem.java
+++ b/src/main/java/org/openhab/automation/jrule/items/JRuleGroupItem.java
@@ -39,18 +39,22 @@ public interface JRuleGroupItem<I extends JRuleItem> extends JRuleItem {
     }
 
     default void sendUncheckedCommand(JRuleValue command) {
+        JRuleEventHandler.get().sendCommand(getName(), command);
         JRuleEventHandler.get().getGroupMemberItems(getName(), false).forEach(i -> i.sendUncheckedCommand(command));
     }
 
     default void postUncheckedUpdate(JRuleValue state) {
+        JRuleEventHandler.get().postUpdate(getName(), state);
         JRuleEventHandler.get().getGroupMemberItems(getName(), false).forEach(i -> i.postUncheckedUpdate(state));
     }
 
     default void postUpdate(JRuleRefreshValue state) {
+        JRuleEventHandler.get().postUpdate(getName(), state);
         JRuleEventHandler.get().getGroupMemberItems(getName(), false).forEach(i -> i.postUncheckedUpdate(state));
     }
 
     default void postNullUpdate() {
+        JRuleEventHandler.get().postUpdate(getName(), null);
         JRuleEventHandler.get().getGroupMemberItems(getName(), false).forEach(JRuleItem::postNullUpdate);
     }
 

--- a/src/main/java/org/openhab/automation/jrule/items/JRuleImageGroupItem.java
+++ b/src/main/java/org/openhab/automation/jrule/items/JRuleImageGroupItem.java
@@ -46,6 +46,7 @@ public interface JRuleImageGroupItem extends JRuleImageItem, JRuleGroupItem<JRul
     }
 
     default void postUpdate(JRuleRawValue state) {
+        JRuleEventHandler.get().postUpdate(getName(), state);
         JRuleEventHandler.get().getGroupMemberItems(getName(), false).forEach(i -> i.postUncheckedUpdate(state));
     }
 }

--- a/src/main/java/org/openhab/automation/jrule/items/JRuleLocationGroupItem.java
+++ b/src/main/java/org/openhab/automation/jrule/items/JRuleLocationGroupItem.java
@@ -46,10 +46,12 @@ public interface JRuleLocationGroupItem extends JRuleLocationItem, JRuleGroupIte
     }
 
     default void sendCommand(JRulePointValue command) {
+        JRuleEventHandler.get().sendCommand(getName(), command);
         JRuleEventHandler.get().getGroupMemberItems(getName(), false).forEach(i -> i.sendUncheckedCommand(command));
     }
 
     default void postUpdate(JRulePointValue state) {
+        JRuleEventHandler.get().postUpdate(getName(), state);
         JRuleEventHandler.get().getGroupMemberItems(getName(), false).forEach(i -> i.postUncheckedUpdate(state));
     }
 }

--- a/src/main/java/org/openhab/automation/jrule/items/JRuleNumberGroupItem.java
+++ b/src/main/java/org/openhab/automation/jrule/items/JRuleNumberGroupItem.java
@@ -46,29 +46,35 @@ public interface JRuleNumberGroupItem extends JRuleNumberItem, JRuleGroupItem<JR
     }
 
     default void sendCommand(JRuleDecimalValue command) {
+        JRuleEventHandler.get().sendCommand(getName(), command);
         JRuleEventHandler.get().getGroupMemberItems(getName(), false).forEach(i -> i.sendUncheckedCommand(command));
     }
 
     default void postUpdate(JRuleDecimalValue state) {
+        JRuleEventHandler.get().postUpdate(getName(), state);
         JRuleEventHandler.get().getGroupMemberItems(getName(), false).forEach(i -> i.postUncheckedUpdate(state));
     }
 
     default void sendCommand(double command) {
+        JRuleEventHandler.get().sendCommand(getName(), new JRuleDecimalValue(command));
         JRuleEventHandler.get().getGroupMemberItems(getName(), false)
                 .forEach(i -> i.sendUncheckedCommand(new JRuleDecimalValue(command)));
     }
 
     default void sendCommand(int command) {
+        JRuleEventHandler.get().sendCommand(getName(), new JRuleDecimalValue(command));
         JRuleEventHandler.get().getGroupMemberItems(getName(), false)
                 .forEach(i -> i.sendUncheckedCommand(new JRuleDecimalValue(command)));
     }
 
     default void postUpdate(double state) {
+        JRuleEventHandler.get().postUpdate(getName(), new JRuleDecimalValue(state));
         JRuleEventHandler.get().getGroupMemberItems(getName(), false)
                 .forEach(i -> i.postUncheckedUpdate(new JRuleDecimalValue(state)));
     }
 
     default void postUpdate(int state) {
+        JRuleEventHandler.get().postUpdate(getName(), new JRuleDecimalValue(state));
         JRuleEventHandler.get().getGroupMemberItems(getName(), false)
                 .forEach(i -> i.postUncheckedUpdate(new JRuleDecimalValue(state)));
     }

--- a/src/main/java/org/openhab/automation/jrule/items/JRulePlayerGroupItem.java
+++ b/src/main/java/org/openhab/automation/jrule/items/JRulePlayerGroupItem.java
@@ -20,7 +20,9 @@ import org.openhab.automation.jrule.exception.JRuleItemNotFoundException;
 import org.openhab.automation.jrule.internal.JRuleUtil;
 import org.openhab.automation.jrule.internal.handler.JRuleEventHandler;
 import org.openhab.automation.jrule.internal.items.JRuleInternalPlayerGroupItem;
-import org.openhab.automation.jrule.rules.value.*;
+import org.openhab.automation.jrule.rules.value.JRuleNextPreviousValue;
+import org.openhab.automation.jrule.rules.value.JRulePlayPauseValue;
+import org.openhab.automation.jrule.rules.value.JRuleRewindFastforwardValue;
 
 /**
  * The {@link JRulePlayerGroupItem} Items
@@ -46,18 +48,22 @@ public interface JRulePlayerGroupItem extends JRulePlayerItem, JRuleGroupItem<JR
     }
 
     default void sendCommand(JRulePlayPauseValue command) {
+        JRuleEventHandler.get().sendCommand(getName(), command);
         JRuleEventHandler.get().getGroupMemberItems(getName(), false).forEach(i -> i.sendUncheckedCommand(command));
     }
 
     default void postUpdate(JRulePlayPauseValue state) {
+        JRuleEventHandler.get().postUpdate(getName(), state);
         JRuleEventHandler.get().getGroupMemberItems(getName(), false).forEach(i -> i.postUncheckedUpdate(state));
     }
 
     default void sendCommand(JRuleRewindFastforwardValue command) {
+        JRuleEventHandler.get().sendCommand(getName(), command);
         JRuleEventHandler.get().getGroupMemberItems(getName(), false).forEach(i -> i.sendUncheckedCommand(command));
     }
 
     default void sendCommand(JRuleNextPreviousValue command) {
+        JRuleEventHandler.get().sendCommand(getName(), command);
         JRuleEventHandler.get().getGroupMemberItems(getName(), false).forEach(i -> i.sendUncheckedCommand(command));
     }
 }

--- a/src/main/java/org/openhab/automation/jrule/items/JRuleQuantityGroupItem.java
+++ b/src/main/java/org/openhab/automation/jrule/items/JRuleQuantityGroupItem.java
@@ -46,29 +46,35 @@ public interface JRuleQuantityGroupItem extends JRuleQuantityItem, JRuleGroupIte
     }
 
     default void sendCommand(JRuleQuantityValue command) {
+        JRuleEventHandler.get().sendCommand(getName(), command);
         JRuleEventHandler.get().getGroupMemberItems(getName(), false).forEach(i -> i.sendUncheckedCommand(command));
     }
 
     default void sendCommand(double command, String unit) {
+        JRuleEventHandler.get().sendCommand(getName(), new JRuleQuantityValue(command, unit));
         JRuleEventHandler.get().getGroupMemberItems(getName(), false)
                 .forEach(i -> i.sendUncheckedCommand(new JRuleQuantityValue(command, unit)));
     }
 
     default void sendCommand(int command, String unit) {
+        JRuleEventHandler.get().sendCommand(getName(), new JRuleQuantityValue(command, unit));
         JRuleEventHandler.get().getGroupMemberItems(getName(), false)
                 .forEach(i -> i.sendUncheckedCommand(new JRuleQuantityValue(command, unit)));
     }
 
     default void postUpdate(JRuleQuantityValue state) {
+        JRuleEventHandler.get().postUpdate(getName(), state);
         JRuleEventHandler.get().getGroupMemberItems(getName(), false).forEach(i -> i.postUncheckedUpdate(state));
     }
 
     default void postUpdate(double state, String unit) {
+        JRuleEventHandler.get().postUpdate(getName(), new JRuleQuantityValue(state, unit));
         JRuleEventHandler.get().getGroupMemberItems(getName(), false)
                 .forEach(i -> i.postUncheckedUpdate(new JRuleQuantityValue(state, unit)));
     }
 
     default void postUpdate(int state, String unit) {
+        JRuleEventHandler.get().postUpdate(getName(), new JRuleQuantityValue(state, unit));
         JRuleEventHandler.get().getGroupMemberItems(getName(), false)
                 .forEach(i -> i.postUncheckedUpdate(new JRuleQuantityValue(state, unit)));
     }

--- a/src/main/java/org/openhab/automation/jrule/items/JRuleRollershutterGroupItem.java
+++ b/src/main/java/org/openhab/automation/jrule/items/JRuleRollershutterGroupItem.java
@@ -20,7 +20,9 @@ import org.openhab.automation.jrule.exception.JRuleItemNotFoundException;
 import org.openhab.automation.jrule.internal.JRuleUtil;
 import org.openhab.automation.jrule.internal.handler.JRuleEventHandler;
 import org.openhab.automation.jrule.internal.items.JRuleInternalRollershutterGroupItem;
-import org.openhab.automation.jrule.rules.value.*;
+import org.openhab.automation.jrule.rules.value.JRulePercentValue;
+import org.openhab.automation.jrule.rules.value.JRuleStopMoveValue;
+import org.openhab.automation.jrule.rules.value.JRuleUpDownValue;
 
 /**
  * The {@link JRuleRollershutterGroupItem} Items
@@ -46,27 +48,33 @@ public interface JRuleRollershutterGroupItem extends JRuleRollershutterItem, JRu
     }
 
     default void sendCommand(JRulePercentValue command) {
+        JRuleEventHandler.get().sendCommand(getName(), command);
         JRuleEventHandler.get().getGroupMemberItems(getName(), false).forEach(i -> i.sendUncheckedCommand(command));
     }
 
     default void postUpdate(JRulePercentValue state) {
+        JRuleEventHandler.get().postUpdate(getName(), state);
         JRuleEventHandler.get().getGroupMemberItems(getName(), false).forEach(i -> i.postUncheckedUpdate(state));
     }
 
     default void sendCommand(int command) {
+        JRuleEventHandler.get().sendCommand(getName(), new JRulePercentValue(command));
         JRuleEventHandler.get().getGroupMemberItems(getName(), false)
                 .forEach(i -> i.sendUncheckedCommand(new JRulePercentValue(command)));
     }
 
     default void sendCommand(JRuleUpDownValue command) {
+        JRuleEventHandler.get().sendCommand(getName(), command);
         JRuleEventHandler.get().getGroupMemberItems(getName(), false).forEach(i -> i.sendUncheckedCommand(command));
     }
 
     default void sendCommand(JRuleStopMoveValue command) {
+        JRuleEventHandler.get().sendCommand(getName(), command);
         JRuleEventHandler.get().getGroupMemberItems(getName(), false).forEach(i -> i.sendUncheckedCommand(command));
     }
 
     default void postUpdate(int state) {
+        JRuleEventHandler.get().postUpdate(getName(), new JRulePercentValue(state));
         JRuleEventHandler.get().getGroupMemberItems(getName(), false)
                 .forEach(i -> i.postUncheckedUpdate(new JRulePercentValue(state)));
     }

--- a/src/main/java/org/openhab/automation/jrule/items/JRuleStringGroupItem.java
+++ b/src/main/java/org/openhab/automation/jrule/items/JRuleStringGroupItem.java
@@ -46,19 +46,23 @@ public interface JRuleStringGroupItem extends JRuleStringItem, JRuleGroupItem<JR
     }
 
     default void sendCommand(JRuleStringValue command) {
+        JRuleEventHandler.get().sendCommand(getName(), command);
         JRuleEventHandler.get().getGroupMemberItems(getName(), false).forEach(i -> i.sendUncheckedCommand(command));
     }
 
     default void postUpdate(JRuleStringValue state) {
+        JRuleEventHandler.get().postUpdate(getName(), state);
         JRuleEventHandler.get().getGroupMemberItems(getName(), false).forEach(i -> i.postUncheckedUpdate(state));
     }
 
     default void sendCommand(String command) {
+        JRuleEventHandler.get().sendCommand(getName(), new JRuleStringValue(command));
         JRuleEventHandler.get().getGroupMemberItems(getName(), false)
                 .forEach(i -> i.sendUncheckedCommand(new JRuleStringValue(command)));
     }
 
     default void postUpdate(String state) {
+        JRuleEventHandler.get().postUpdate(getName(), new JRuleStringValue(state));
         JRuleEventHandler.get().getGroupMemberItems(getName(), false)
                 .forEach(m -> m.postUncheckedUpdate(new JRuleStringValue(state)));
     }

--- a/src/main/java/org/openhab/automation/jrule/items/JRuleSwitchGroupItem.java
+++ b/src/main/java/org/openhab/automation/jrule/items/JRuleSwitchGroupItem.java
@@ -46,19 +46,23 @@ public interface JRuleSwitchGroupItem extends JRuleSwitchItem, JRuleGroupItem<JR
     }
 
     default void sendCommand(JRuleOnOffValue command) {
+        JRuleEventHandler.get().sendCommand(getName(), command);
         JRuleEventHandler.get().getGroupMemberItems(getName(), false).forEach(i -> i.sendUncheckedCommand(command));
     }
 
     default void postUpdate(JRuleOnOffValue state) {
+        JRuleEventHandler.get().postUpdate(getName(), state);
         JRuleEventHandler.get().getGroupMemberItems(getName(), false).forEach(i -> i.postUncheckedUpdate(state));
     }
 
     default void sendCommand(boolean command) {
+        JRuleEventHandler.get().sendCommand(getName(), JRuleOnOffValue.valueOf(command));
         JRuleEventHandler.get().getGroupMemberItems(getName(), false)
                 .forEach(i -> i.sendUncheckedCommand(JRuleOnOffValue.valueOf(command)));
     }
 
     default void postUpdate(boolean state) {
+        JRuleEventHandler.get().postUpdate(getName(), JRuleOnOffValue.valueOf(state));
         JRuleEventHandler.get().getGroupMemberItems(getName(), false)
                 .forEach(i -> i.postUncheckedUpdate(JRuleOnOffValue.valueOf(state)));
     }

--- a/src/test/java/org/openhab/automation/jrule/items/JRuleItemTestBase.java
+++ b/src/test/java/org/openhab/automation/jrule/items/JRuleItemTestBase.java
@@ -12,16 +12,25 @@
  */
 package org.openhab.automation.jrule.items;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Optional;
 
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
 import org.mockito.Mockito;
 import org.openhab.automation.jrule.exception.JRuleItemNotFoundException;
 import org.openhab.automation.jrule.internal.handler.JRuleEventHandler;
 import org.openhab.automation.jrule.rules.value.JRuleValue;
 import org.openhab.core.events.Event;
 import org.openhab.core.events.EventPublisher;
-import org.openhab.core.items.*;
+import org.openhab.core.items.GenericItem;
+import org.openhab.core.items.GroupItem;
+import org.openhab.core.items.ItemNotFoundException;
+import org.openhab.core.items.ItemRegistry;
+import org.openhab.core.items.MetadataRegistry;
 import org.openhab.core.items.events.ItemCommandEvent;
 import org.openhab.core.items.events.ItemStateEvent;
 import org.openhab.core.types.State;
@@ -141,8 +150,8 @@ public abstract class JRuleItemTestBase {
 
     protected void verifyEventTypes(TestInfo testInfo, int wantedStateCalls, int wantedCommandCalls) {
         if (testInfo.getTestClass().orElseThrow().getSimpleName().contains("GroupItem")) {
-            Mockito.verify(eventPublisher, Mockito.times(wantedStateCalls * 3)).post(Mockito.any(ItemStateEvent.class));
-            Mockito.verify(eventPublisher, Mockito.times(wantedCommandCalls * 3))
+            Mockito.verify(eventPublisher, Mockito.times(wantedStateCalls * 5)).post(Mockito.any(ItemStateEvent.class));
+            Mockito.verify(eventPublisher, Mockito.times(wantedCommandCalls * 5))
                     .post(Mockito.any(ItemCommandEvent.class));
         } else {
             Mockito.verify(eventPublisher, Mockito.times(wantedStateCalls)).post(Mockito.any(ItemStateEvent.class));


### PR DESCRIPTION
Currently when sending commands/updates to group items, the state/command is not updated for the group itself, only member items. This makes it impossible to listen for group commands originating from Jrule, but works when sending from ie openhab-console or android app.