### PR TITLE
print useful exception trace while InvocationTargetException

### DIFF
--- a/src/main/java/org/openhab/automation/jrule/internal/engine/JRuleEngine.java
+++ b/src/main/java/org/openhab/automation/jrule/internal/engine/JRuleEngine.java
@@ -535,7 +535,7 @@ public class JRuleEngine implements PropertyChangeListener {
                     ExceptionUtils.getStackTrace(e));
         } catch (InvocationTargetException e) {
             JRuleLog.error(logger, context.getMethod().getName(), "Error in rule: {}",
-                    ExceptionUtils.getStackTrace(e.getCause()));
+                    ExceptionUtils.getStackTrace(e.getTargetException()));
         } finally {
             Arrays.stream(context.getLoggingTags()).forEach(MDC::remove);
             MDC.remove(MDC_KEY_RULE);


### PR DESCRIPTION
Currently there is for example just 
`Error in rule: java.lang.ClassCastException`
This is helpless. Now there is the real exception stacktrace.