### PR TITLE
MethodNotFound fix for primitive action parameters

### DIFF
--- a/src/main/java/org/openhab/automation/jrule/actions/JRuleActionClassGenerator.java
+++ b/src/main/java/org/openhab/automation/jrule/actions/JRuleActionClassGenerator.java
@@ -25,7 +25,6 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
 
-import org.apache.commons.lang3.ClassUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.openhab.automation.jrule.internal.JRuleConfig;
@@ -180,8 +179,8 @@ public class JRuleActionClassGenerator extends JRuleAbstractClassGenerator {
                                 Map<Object, Object> arg = new HashMap<>();
                                 Class<?> parameterType = replaceTypeIfNecessary(parameter.getType());
                                 arg.put("type", parameterType.getTypeName());
-                                arg.put("reflectionType", ClassUtils.primitiveToWrapper(parameter.getType())
-                                        .getTypeName().replaceFirst("java.lang.", ""));
+                                arg.put("reflectionType",
+                                        parameter.getType().getTypeName().replaceFirst("java.lang.", ""));
                                 arg.put("name", parameter.getAnnotation(ActionInput.class).name());
                                 args.add(arg);
                             }

--- a/src/test/java/org/openhab/automation/jrule/internal/codegenerator/JRuleActionClassGeneratorTest.java
+++ b/src/test/java/org/openhab/automation/jrule/internal/codegenerator/JRuleActionClassGeneratorTest.java
@@ -152,6 +152,10 @@ public class JRuleActionClassGeneratorTest {
         Object res = doSomethingAbstract.invoke(action, new StringType("blub"));
         assertEquals(10, res);
 
+        Method doSomething = action.getClass().getDeclaredMethod("doSomething", String.class, int.class, Float.class);
+        doSomething.invoke(action, "hi", (int) 5, 3.7f);
+        assertEquals(10, res);
+
         // Verify method with unsupported types are mapped to Object
         Method returnObjectOnUnsupportedClass = action.getClass().getDeclaredMethod("returnObjectOnUnsupportedClass",
                 Object.class);

--- a/src/test/java/org/openhab/automation/jrule/internal/codegenerator/JRuleActionClassGeneratorTest.java
+++ b/src/test/java/org/openhab/automation/jrule/internal/codegenerator/JRuleActionClassGeneratorTest.java
@@ -153,7 +153,7 @@ public class JRuleActionClassGeneratorTest {
         assertEquals(10, res);
 
         Method doSomething = action.getClass().getDeclaredMethod("doSomething", String.class, int.class, Float.class);
-        doSomething.invoke(action, "hi", (int) 5, 3.7f);
+        doSomething.invoke(action, "hi", 5, 3.7f);
         assertEquals(10, res);
 
         // Verify method with unsupported types are mapped to Object


### PR DESCRIPTION
fixed MethodNotFound error when using actions with primitive types
see https://github.com/seaside1/jrule/issues/182