### PR TITLE
for InvocationTargetException the get stacktrace has changed from get…

### DIFF
--- a/src/main/java/org/openhab/automation/jrule/internal/engine/JRuleEngine.java
+++ b/src/main/java/org/openhab/automation/jrule/internal/engine/JRuleEngine.java
@@ -556,7 +556,7 @@ public class JRuleEngine implements PropertyChangeListener {
                     ExceptionUtils.getStackTrace(e));
         } catch (InvocationTargetException e) {
             JRuleLog.error(logger, context.getMethod().getName(), "Error in rule: {}\ntarget: {}",
-                    ExceptionUtils.getStackTrace(e), ExceptionUtils.getStackTrace(e.getTargetException()));
+                    ExceptionUtils.getStackTrace(e), ExceptionUtils.getStackTrace(e.getCause()));
         } finally {
             Arrays.stream(context.getLoggingTags()).forEach(MDC::remove);
             MDC.remove(MDC_KEY_RULE);


### PR DESCRIPTION
for InvocationTargetException the get stacktrace has changed from getTargetException() to getCause()
I changed the jdk from zulu to temurin and my stacktraces are lost. getTargetException() just gives me the exception message, not the stacktrace anymore.
With the new implementation the caused by it logged twice now. I am afraid to remove the `\ntarget: {}` part that in some cases the caused by stacktrace isn't printed anymore in some jdk versions.