### PR TITLE
quantity item should extend number item

### DIFF
--- a/src/main/java/org/openhab/automation/jrule/items/JRuleQuantityItem.java
+++ b/src/main/java/org/openhab/automation/jrule/items/JRuleQuantityItem.java
@@ -12,7 +12,6 @@
  */
 package org.openhab.automation.jrule.items;
 
-import java.time.ZonedDateTime;
 import java.util.Optional;
 
 import org.openhab.automation.jrule.exception.JRuleItemNotFoundException;
@@ -27,7 +26,7 @@ import org.openhab.automation.jrule.rules.value.JRuleQuantityValue;
  *
  * @author Robert Delbrück - Initial contribution
  */
-public interface JRuleQuantityItem extends JRuleItem {
+public interface JRuleQuantityItem extends JRuleNumberItem {
     static JRuleQuantityItem forName(String itemName) throws JRuleItemNotFoundException {
         return JRuleItemRegistry.get(itemName, JRuleInternalQuantityItem.class);
     }
@@ -131,46 +130,10 @@ public interface JRuleQuantityItem extends JRuleItem {
     }
 
     default JRuleDecimalValue getStateAsDecimal() {
-        return JRuleEventHandler.get().getValue(getName(), JRuleDecimalValue.class);
+        return new JRuleDecimalValue(getStateAsQuantity().doubleValue());
     }
 
     default JRuleQuantityValue getStateAsQuantity() {
         return JRuleEventHandler.get().getValue(getName(), JRuleQuantityValue.class);
     }
-
-    default Optional<Double> maximumSince(ZonedDateTime timestamp) {
-        return maximumSince(timestamp, null);
-    }
-
-    Optional<Double> maximumSince(ZonedDateTime timestamp, String persistenceServiceId);
-
-    default Optional<Double> minimumSince(ZonedDateTime timestamp) {
-        return minimumSince(timestamp, null);
-    }
-
-    Optional<Double> minimumSince(ZonedDateTime timestamp, String persistenceServiceId);
-
-    default Optional<Double> varianceSince(ZonedDateTime timestamp) {
-        return varianceSince(timestamp, null);
-    }
-
-    Optional<Double> varianceSince(ZonedDateTime timestamp, String persistenceServiceId);
-
-    default Optional<Double> deviationSince(ZonedDateTime timestamp) {
-        return deviationSince(timestamp, null);
-    }
-
-    Optional<Double> deviationSince(ZonedDateTime timestamp, String persistenceServiceId);
-
-    default Optional<Double> averageSince(ZonedDateTime timestamp) {
-        return averageSince(timestamp, null);
-    }
-
-    Optional<Double> averageSince(ZonedDateTime timestamp, String persistenceServiceId);
-
-    default Optional<Double> sumSince(ZonedDateTime timestamp) {
-        return sumSince(timestamp, null);
-    }
-
-    Optional<Double> sumSince(ZonedDateTime timestamp, String persistenceServiceId);
 }


### PR DESCRIPTION
When a NumberGroupItem has Quantity GroupItems as well there will be class cast exceptions because currently a NumberGroupItem expects that all childs are NumberItems.
Letting QuantityItem extend NumberItem will resolve this.