### PR TITLE
Dynamic rule ruilder

### DIFF
--- a/doc/EXAMPLES.md
+++ b/doc/EXAMPLES.md
@@ -44,6 +44,7 @@
     + [Example 40 - Delay rule execution](#example-40---delay-rule-execution)
     + [Example 41 - Get Metadata and Tags](#example-41---get-metadata-and-tags)
     + [Example 42 - Persist future data](#example-42---persist-future-data)
+    + [Example 43 - Creating a rule dynamically using JRuleBuilder](#example-43---creating-a-rule-dynamically-using-jrulebuilder)
 
 ### Example 1 - Invoke another item Switch from rule
 

--- a/doc/EXAMPLES.md
+++ b/doc/EXAMPLES.md
@@ -1094,3 +1094,33 @@ public class DemoRule extends JRule {
   }
 }
 ```
+
+## Example 43 - Creating a rule dynamically using JRuleBuilder
+
+Use case: Build a rule dynamically during runtime without static annotations. Can be used when rule parameters are not
+known at compile time, e.g. when they are read from a configuration file
+
+```java
+package org.openhab.automation.jrule.rules.user;
+
+import org.openhab.automation.jrule.internal.engine.JRuleEngine;
+import org.openhab.automation.jrule.rules.JRule;
+import org.openhab.automation.jrule.rules.JRuleMemberOf;
+
+public class DynamicRuleModule extends JRule {
+
+    public DynamicRuleModule() {
+        registerDynamicRules();
+    }
+
+    private void registerDynamicRules() {
+        logInfo("Registering Dynamic JRules");
+
+        JRuleEngine.get().createJRuleBuilder("Example dynamic rule", event ->
+                        logInfo("Received command {}", event)
+                )
+                .whenItemChange("MyItem", JRuleMemberOf.None, "OFF", "ON", null, null)
+                .build();
+    }
+}
+```

--- a/src/main/java/org/openhab/automation/jrule/internal/engine/JRuleBuilder.java
+++ b/src/main/java/org/openhab/automation/jrule/internal/engine/JRuleBuilder.java
@@ -1,0 +1,285 @@
+/**
+ * Copyright (c) 2010-2023 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.automation.jrule.internal.engine;
+
+import static org.openhab.automation.jrule.internal.engine.JRuleEngine.EMPTY_LOG_TAGS;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.automation.jrule.internal.engine.excutioncontext.JRuleChannelExecutionContext;
+import org.openhab.automation.jrule.internal.engine.excutioncontext.JRuleItemChangeExecutionContext;
+import org.openhab.automation.jrule.internal.engine.excutioncontext.JRuleItemExecutionContext;
+import org.openhab.automation.jrule.internal.engine.excutioncontext.JRuleItemReceivedCommandExecutionContext;
+import org.openhab.automation.jrule.internal.engine.excutioncontext.JRuleItemReceivedUpdateExecutionContext;
+import org.openhab.automation.jrule.internal.engine.excutioncontext.JRulePreconditionContext;
+import org.openhab.automation.jrule.internal.engine.excutioncontext.JRuleThingExecutionContext;
+import org.openhab.automation.jrule.internal.engine.excutioncontext.JRuleTimeTimerExecutionContext;
+import org.openhab.automation.jrule.internal.engine.excutioncontext.JRuleTimedCronExecutionContext;
+import org.openhab.automation.jrule.internal.module.JRuleModuleEntry;
+import org.openhab.automation.jrule.rules.JRuleMemberOf;
+import org.openhab.automation.jrule.things.JRuleThingStatus;
+
+/**
+ * The {@link JRuleBuilder}
+ *
+ * @author Rüdiger Sopp - Initial contribution
+ */
+public class JRuleBuilder {
+
+    private final JRuleEngine jRuleEngine;
+
+    private final JRuleInvocationCallback invocationCallback;
+    private final String ruleName;
+    private boolean enableRule = false;
+    private String uid = null;
+    private String logName = null;
+    private String[] loggingTags = EMPTY_LOG_TAGS;
+    private Duration timedLock = null;
+    private Duration delayed = null;
+
+    final private List<PreCondition> preConditions = new ArrayList<>();
+
+    final private List<WhenThingTrigger> whenThingTriggers = new ArrayList<>();
+    final private List<WhenChannelTrigger> whenChannelTriggers = new ArrayList<>();
+    final private List<WhenItemReceivedCommand> whenItemReceivedCommandTriggers = new ArrayList<>();
+    final private List<WhenItemChanged> whenItemChangedTriggers = new ArrayList<>();
+    final private List<WhenItemReceivedUpdate> whenItemReceivedUpdateTriggers = new ArrayList<>();
+    final private List<WhenCronTrigger> whenCronTriggers = new ArrayList<>();
+    final private List<WhenTimeTrigger> whenTimeTriggers = new ArrayList<>();
+
+    JRuleBuilder(JRuleEngine jRuleEngine, String ruleName, JRuleInvocationCallback invocationCallback) {
+        this.jRuleEngine = jRuleEngine;
+        this.ruleName = ruleName;
+        this.invocationCallback = invocationCallback;
+    }
+
+    public JRuleBuilder enableRule(boolean enableRule) {
+        this.enableRule = enableRule;
+        return this;
+    }
+
+    public JRuleBuilder uid(String uid) {
+        this.uid = uid;
+        return this;
+    }
+
+    public JRuleBuilder logName(String logName) {
+        this.logName = logName;
+        return this;
+    }
+
+    public JRuleBuilder loggingTags(String[] loggingTags) {
+        this.loggingTags = loggingTags;
+        return this;
+    }
+
+    public JRuleBuilder timedLock(Duration timedLock) {
+        this.timedLock = timedLock;
+        return this;
+    }
+
+    public JRuleBuilder delayed(Duration delayed) {
+        this.delayed = delayed;
+        return this;
+    }
+
+    public JRuleBuilder preCondition(String itemName, Condition condition) {
+        preConditions.add(new PreCondition(itemName, condition));
+        return this;
+    }
+
+    public JRuleBuilder whenThingTrigger(String thingName, @Nullable JRuleThingStatus from,
+            @Nullable JRuleThingStatus to) {
+        whenThingTriggers.add(new WhenThingTrigger(thingName, from, to));
+        return this;
+    }
+
+    public JRuleBuilder whenChannelTrigger(String channelName, @Nullable String event) {
+        whenChannelTriggers.add(new WhenChannelTrigger(channelName, event));
+        return this;
+    }
+
+    public JRuleBuilder whenItemReceivedCommand(String itemName, JRuleMemberOf memberOf, @Nullable String command,
+            @Nullable Condition condition) {
+        whenItemReceivedCommandTriggers.add(new WhenItemReceivedCommand(itemName, memberOf, command, condition));
+        return this;
+    }
+
+    public JRuleBuilder whenItemChange(String itemName, JRuleMemberOf memberOf, @Nullable String from,
+            @Nullable String to, @Nullable Condition previousCondition, @Nullable Condition condition) {
+        whenItemChangedTriggers.add(new WhenItemChanged(itemName, memberOf, from, to, previousCondition, condition));
+        return this;
+    }
+
+    public JRuleBuilder whenItemReceivedUpdate(String itemName, JRuleMemberOf memberOf, @Nullable String state,
+            @Nullable Condition condition) {
+        whenItemReceivedUpdateTriggers.add(new WhenItemReceivedUpdate(itemName, memberOf, state, condition));
+        return this;
+    }
+
+    public JRuleBuilder whenCronTrigger(String cron) {
+        whenCronTriggers.add(new WhenCronTrigger(cron));
+        return this;
+    }
+
+    public JRuleBuilder whenTimeTrigger(@Nullable Integer hour, @Nullable Integer minute, @Nullable Integer second) {
+        whenTimeTriggers.add(new WhenTimeTrigger(hour, minute, second));
+        return this;
+    }
+
+    public boolean build() {
+        if (uid == null) {
+            uid = UUID.randomUUID().toString();
+        }
+
+        if (logName == null) {
+            logName = ruleName;
+        }
+
+        final JRuleModuleEntry ruleModuleEntry = new JRuleModuleEntry(uid, ruleName);
+        ruleModuleEntry.addTags(loggingTags);
+
+        AtomicBoolean addedToContext = new AtomicBoolean(false);
+
+        List<JRulePreconditionContext> preconditionContexts = preConditions.stream()
+                .map(data -> new JRulePreconditionContext(data.itemName, Optional.ofNullable(data.condition.lt),
+                        Optional.ofNullable(data.condition.lte), Optional.ofNullable(data.condition.gt),
+                        Optional.ofNullable(data.condition.gte), Optional.ofNullable(data.condition.eq),
+                        Optional.ofNullable(data.condition.neq)))
+                .toList();
+
+        whenThingTriggers.forEach(data -> {
+            JRuleThingExecutionContext context = new JRuleThingExecutionContext(uid, logName, loggingTags,
+                    invocationCallback, Optional.ofNullable(data.thingName), Optional.ofNullable(data.from),
+                    Optional.ofNullable(data.to), preconditionContexts, timedLock, delayed);
+            jRuleEngine.addToContext(context, enableRule);
+            jRuleEngine.ruleLoadingStatistics.addThingTrigger();
+            ruleModuleEntry.addJRuleWhenThingTrigger(context);
+            addedToContext.set(true);
+        });
+
+        whenChannelTriggers.forEach(data -> {
+            JRuleChannelExecutionContext context = new JRuleChannelExecutionContext(uid, logName, loggingTags,
+                    invocationCallback, preconditionContexts, data.channelName, Optional.ofNullable(data.event),
+                    timedLock, delayed);
+            jRuleEngine.addToContext(context, enableRule);
+            jRuleEngine.ruleLoadingStatistics.addChannelTrigger();
+            ruleModuleEntry.addJRuleWhenChannelTrigger(context);
+            addedToContext.set(true);
+        });
+
+        whenItemReceivedCommandTriggers.forEach(data -> {
+            JRuleItemReceivedCommandExecutionContext context = new JRuleItemReceivedCommandExecutionContext(uid,
+                    logName, loggingTags, invocationCallback, data.itemName, data.memberOf,
+                    Optional.ofNullable(data.condition).map(Condition::toJRuleConditionContext), preconditionContexts,
+                    Optional.ofNullable(data.command), timedLock, delayed);
+
+            jRuleEngine.addToContext(context, enableRule);
+            jRuleEngine.ruleLoadingStatistics.addItemStateTrigger();
+            ruleModuleEntry.addJRuleWhenItemReceivedCommand(context);
+            addedToContext.set(true);
+        });
+
+        whenItemChangedTriggers.forEach(data -> {
+            JRuleItemChangeExecutionContext context = new JRuleItemChangeExecutionContext(uid, logName, loggingTags,
+                    invocationCallback, data.itemName, data.memberOf,
+                    Optional.ofNullable(data.condition).map(Condition::toJRuleConditionContext),
+                    Optional.ofNullable(data.previousCondition).map(Condition::toJRuleConditionContext),
+                    preconditionContexts, Optional.ofNullable(data.from), Optional.ofNullable(data.to), timedLock,
+                    delayed);
+
+            jRuleEngine.addToContext(context, enableRule);
+            jRuleEngine.ruleLoadingStatistics.addItemStateTrigger();
+            ruleModuleEntry.addJRuleWhenItemChange(context);
+            addedToContext.set(true);
+        });
+
+        whenItemReceivedUpdateTriggers.forEach(data -> {
+            JRuleItemReceivedUpdateExecutionContext context = new JRuleItemReceivedUpdateExecutionContext(uid, logName,
+                    loggingTags, invocationCallback, data.itemName, data.memberOf,
+                    Optional.ofNullable(data.condition).map(Condition::toJRuleConditionContext), preconditionContexts,
+                    Optional.ofNullable(data.state), timedLock, delayed);
+
+            jRuleEngine.addToContext(context, enableRule);
+            jRuleEngine.ruleLoadingStatistics.addItemStateTrigger();
+            ruleModuleEntry.addJRuleWhenItemReceivedUpdate(context);
+            addedToContext.set(true);
+        });
+
+        whenCronTriggers.forEach(data -> {
+            JRuleTimedCronExecutionContext context = new JRuleTimedCronExecutionContext(uid, logName, loggingTags,
+                    invocationCallback, preconditionContexts, data.cron);
+
+            jRuleEngine.addToContext(context, enableRule);
+            jRuleEngine.ruleLoadingStatistics.addTimedTrigger();
+            ruleModuleEntry.addJRuleWhenCronTrigger(context);
+            addedToContext.set(true);
+        });
+
+        whenTimeTriggers.forEach(data -> {
+            JRuleTimeTimerExecutionContext context = new JRuleTimeTimerExecutionContext(uid, logName, loggingTags,
+                    invocationCallback, preconditionContexts, Optional.ofNullable(data.hour),
+                    Optional.ofNullable(data.minute), Optional.ofNullable(data.second));
+            jRuleEngine.addToContext(context, enableRule);
+            jRuleEngine.ruleLoadingStatistics.addTimedTrigger();
+            ruleModuleEntry.addJRuleWhenTimeTrigger(context);
+            addedToContext.set(true);
+        });
+
+        jRuleEngine.ruleProvider.add(ruleModuleEntry);
+
+        return addedToContext.get();
+    }
+
+    public record Condition(@Nullable Double lt, @Nullable Double lte, @Nullable Double gt, @Nullable Double gte,
+            @Nullable String eq, @Nullable String neq) {
+
+        private JRuleItemExecutionContext.JRuleConditionContext toJRuleConditionContext() {
+            return new JRuleItemExecutionContext.JRuleConditionContext(Optional.ofNullable(gt),
+                    Optional.ofNullable(gte), Optional.ofNullable(lt), Optional.ofNullable(lte),
+                    Optional.ofNullable(eq), Optional.ofNullable(neq));
+        }
+    }
+
+    private record PreCondition(String itemName, Condition condition) {
+    }
+
+    private record WhenThingTrigger(String thingName, JRuleThingStatus from, JRuleThingStatus to) {
+    }
+
+    private record WhenChannelTrigger(String channelName, String event) {
+    }
+
+    private record WhenItemReceivedCommand(String itemName, JRuleMemberOf memberOf, String command,
+            Condition condition) {
+    }
+
+    private record WhenItemChanged(String itemName, JRuleMemberOf memberOf, String from, String to,
+            Condition previousCondition, Condition condition) {
+    }
+
+    private record WhenItemReceivedUpdate(String itemName, JRuleMemberOf memberOf, String state, Condition condition) {
+    }
+
+    private record WhenCronTrigger(String cron) {
+    }
+
+    private record WhenTimeTrigger(Integer hour, Integer minute, Integer second) {
+    }
+}

--- a/src/main/java/org/openhab/automation/jrule/internal/engine/JRuleEngine.java
+++ b/src/main/java/org/openhab/automation/jrule/internal/engine/JRuleEngine.java
@@ -133,6 +133,7 @@ public class JRuleEngine implements PropertyChangeListener {
             logInfo("Adding Dynamic Rule Name: {} item: {}", ruleName, itemName);
         }
         jRuleBuilder.build();
+        ruleLoadingStatistics.addRuleClass();
     }
 
     private void add(Method method, JRule jRule, boolean enableRule) {

--- a/src/main/java/org/openhab/automation/jrule/internal/engine/JRuleInvocationCallback.java
+++ b/src/main/java/org/openhab/automation/jrule/internal/engine/JRuleInvocationCallback.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2010-2023 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.automation.jrule.internal.engine;
+
+import org.openhab.automation.jrule.rules.event.JRuleEvent;
+
+/**
+ * The {@link JRuleInvocationCallback}
+ *
+ * @author Rüdiger Sopp - Initial contribution
+ */
+@FunctionalInterface
+public interface JRuleInvocationCallback {
+    void accept(JRuleEvent event);
+}

--- a/src/main/java/org/openhab/automation/jrule/internal/engine/excutioncontext/JRuleChannelExecutionContext.java
+++ b/src/main/java/org/openhab/automation/jrule/internal/engine/excutioncontext/JRuleChannelExecutionContext.java
@@ -12,13 +12,12 @@
  */
 package org.openhab.automation.jrule.internal.engine.excutioncontext;
 
-import java.lang.reflect.Method;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
-import org.openhab.automation.jrule.rules.JRule;
+import org.openhab.automation.jrule.internal.engine.JRuleInvocationCallback;
 import org.openhab.automation.jrule.rules.event.JRuleChannelEvent;
 import org.openhab.automation.jrule.rules.event.JRuleEvent;
 import org.openhab.core.events.AbstractEvent;
@@ -33,10 +32,10 @@ public class JRuleChannelExecutionContext extends JRuleExecutionContext {
     private final String channel;
     private final Optional<String> event;
 
-    public JRuleChannelExecutionContext(JRule jRule, String logName, String[] loggingTags, Method method,
-            List<JRulePreconditionContext> preconditionContextList, String channel, Optional<String> event,
-            Duration timedLock, Duration delayed) {
-        super(jRule, logName, loggingTags, method, preconditionContextList, timedLock, delayed);
+    public JRuleChannelExecutionContext(String uid, String logName, String[] loggingTags,
+            JRuleInvocationCallback invocationCallback, List<JRulePreconditionContext> preconditionContextList,
+            String channel, Optional<String> event, Duration timedLock, Duration delayed) {
+        super(uid, logName, loggingTags, invocationCallback, preconditionContextList, timedLock, delayed);
         this.channel = channel;
         this.event = event;
     }
@@ -65,7 +64,7 @@ public class JRuleChannelExecutionContext extends JRuleExecutionContext {
     @Override
     public String toString() {
         return "JRuleChannelExecutionContext{" + "channel='" + channel + '\'' + ", event=" + event + ", logName='"
-                + logName + '\'' + ", jRule=" + rule + ", method=" + method + ", loggingTags="
+                + logName + '\'' + ", uid=" + uid + ", invocationCallback=" + invocationCallback + ", loggingTags="
                 + Arrays.toString(loggingTags) + ", preconditionContextList=" + preconditionContextList + '}';
     }
 }

--- a/src/main/java/org/openhab/automation/jrule/internal/engine/excutioncontext/JRuleExecutionContext.java
+++ b/src/main/java/org/openhab/automation/jrule/internal/engine/excutioncontext/JRuleExecutionContext.java
@@ -12,12 +12,11 @@
  */
 package org.openhab.automation.jrule.internal.engine.excutioncontext;
 
-import java.lang.reflect.Method;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
 
-import org.openhab.automation.jrule.rules.JRule;
+import org.openhab.automation.jrule.internal.engine.JRuleInvocationCallback;
 import org.openhab.automation.jrule.rules.event.JRuleEvent;
 import org.openhab.core.events.AbstractEvent;
 
@@ -28,8 +27,8 @@ import org.openhab.core.events.AbstractEvent;
  */
 public abstract class JRuleExecutionContext {
     protected final String logName;
-    protected final JRule rule;
-    protected final Method method;
+    protected final String uid;
+    protected final JRuleInvocationCallback invocationCallback;
     protected final String[] loggingTags;
     protected final List<JRulePreconditionContext> preconditionContextList;
     protected final Duration timedLock;
@@ -38,28 +37,24 @@ public abstract class JRuleExecutionContext {
     // If this rule is enabled or disabled in openHAB rules engine
     private boolean enabled = false;
 
-    public JRuleExecutionContext(JRule rule, String logName, String[] loggingTags, Method method,
-            List<JRulePreconditionContext> preconditionContextList, Duration timedLock, Duration delayed) {
+    public JRuleExecutionContext(String uid, String logName, String[] loggingTags,
+            JRuleInvocationCallback invocationCallback, List<JRulePreconditionContext> preconditionContextList,
+            Duration timedLock, Duration delayed) {
         this.logName = logName;
         this.loggingTags = loggingTags;
-        this.rule = rule;
-        this.method = method;
+        this.uid = uid;
+        this.invocationCallback = invocationCallback;
         this.preconditionContextList = preconditionContextList;
         this.timedLock = timedLock;
         this.delayed = delayed;
     }
 
-    public JRule getRule() {
-        return rule;
+    public String getUid() {
+        return uid;
     }
 
-    public Method getMethod() {
-        return method;
-    }
-
-    public boolean hasEventParameterPresent() {
-        return Arrays.stream(method.getParameters())
-                .anyMatch(param -> (JRuleEvent.class.isAssignableFrom(param.getType())));
+    public JRuleInvocationCallback getInvocationCallback() {
+        return invocationCallback;
     }
 
     public String getLogName() {
@@ -80,8 +75,8 @@ public abstract class JRuleExecutionContext {
 
     @Override
     public String toString() {
-        return "JRuleExecutionContext{" + "logName='" + logName + '\'' + ", jRule=" + rule + ", method=" + method
-                + ", loggingTags=" + Arrays.toString(loggingTags) + ", preconditionContextList="
+        return "JRuleExecutionContext{" + "logName='" + logName + '\'' + ", uid=" + uid + ", invocationCallback="
+                + invocationCallback + ", loggingTags=" + Arrays.toString(loggingTags) + ", preconditionContextList="
                 + preconditionContextList + '}';
     }
 

--- a/src/main/java/org/openhab/automation/jrule/internal/engine/excutioncontext/JRuleItemChangeExecutionContext.java
+++ b/src/main/java/org/openhab/automation/jrule/internal/engine/excutioncontext/JRuleItemChangeExecutionContext.java
@@ -12,15 +12,14 @@
  */
 package org.openhab.automation.jrule.internal.engine.excutioncontext;
 
-import java.lang.reflect.Method;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
+import org.openhab.automation.jrule.internal.engine.JRuleInvocationCallback;
 import org.openhab.automation.jrule.internal.handler.JRuleEventHandler;
 import org.openhab.automation.jrule.items.JRuleItem;
-import org.openhab.automation.jrule.rules.JRule;
 import org.openhab.automation.jrule.rules.JRuleMemberOf;
 import org.openhab.automation.jrule.rules.event.JRuleEvent;
 import org.openhab.automation.jrule.rules.event.JRuleItemEvent;
@@ -42,13 +41,13 @@ public class JRuleItemChangeExecutionContext extends JRuleItemExecutionContext {
     private final Optional<String> to;
     private final Optional<JRuleConditionContext> previousConditionContext;
 
-    public JRuleItemChangeExecutionContext(JRule jRule, String logName, String[] loggingTags, Method method,
-            String itemName, JRuleMemberOf memberOf, Optional<JRuleConditionContext> conditionContext,
-            Optional<JRuleConditionContext> previousConditionContext,
+    public JRuleItemChangeExecutionContext(String uid, String logName, String[] loggingTags,
+            JRuleInvocationCallback invocationCallback, String itemName, JRuleMemberOf memberOf,
+            Optional<JRuleConditionContext> conditionContext, Optional<JRuleConditionContext> previousConditionContext,
             List<JRulePreconditionContext> preconditionContextList, Optional<String> from, Optional<String> to,
             Duration timedLock, Duration delayed) {
-        super(jRule, logName, loggingTags, method, itemName, memberOf, conditionContext, preconditionContextList,
-                timedLock, delayed);
+        super(uid, logName, loggingTags, invocationCallback, itemName, memberOf, conditionContext,
+                preconditionContextList, timedLock, delayed);
         this.from = from;
         this.to = to;
         this.previousConditionContext = previousConditionContext;
@@ -115,7 +114,7 @@ public class JRuleItemChangeExecutionContext extends JRuleItemExecutionContext {
     public String toString() {
         return "JRuleItemChangeExecutionContext{" + "from=" + from + ", to=" + to + ", itemName='" + itemName + '\''
                 + ", memberOf=" + memberOf + ", conditionContext=" + conditionContext + ", logName='" + logName + '\''
-                + ", jRule=" + rule + ", method=" + method + ", loggingTags=" + Arrays.toString(loggingTags)
-                + ", preconditionContextList=" + preconditionContextList + '}';
+                + ", uid=" + uid + ", invocationCallback=" + invocationCallback + ", loggingTags="
+                + Arrays.toString(loggingTags) + ", preconditionContextList=" + preconditionContextList + '}';
     }
 }

--- a/src/main/java/org/openhab/automation/jrule/internal/engine/excutioncontext/JRuleItemExecutionContext.java
+++ b/src/main/java/org/openhab/automation/jrule/internal/engine/excutioncontext/JRuleItemExecutionContext.java
@@ -12,14 +12,13 @@
  */
 package org.openhab.automation.jrule.internal.engine.excutioncontext;
 
-import java.lang.reflect.Method;
 import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.math.NumberUtils;
-import org.openhab.automation.jrule.rules.JRule;
+import org.openhab.automation.jrule.internal.engine.JRuleInvocationCallback;
 import org.openhab.automation.jrule.rules.JRuleCondition;
 import org.openhab.automation.jrule.rules.JRuleMemberOf;
 import org.openhab.core.library.types.QuantityType;
@@ -34,10 +33,11 @@ public abstract class JRuleItemExecutionContext extends JRuleExecutionContext {
     protected final JRuleMemberOf memberOf;
     protected final Optional<JRuleConditionContext> conditionContext;
 
-    public JRuleItemExecutionContext(JRule jRule, String logName, String[] loggingTags, Method method, String itemName,
-            JRuleMemberOf memberOf, Optional<JRuleConditionContext> conditionContext,
-            List<JRulePreconditionContext> preconditionContextList, Duration timedLock, Duration delayed) {
-        super(jRule, logName, loggingTags, method, preconditionContextList, timedLock, delayed);
+    public JRuleItemExecutionContext(String uid, String logName, String[] loggingTags,
+            JRuleInvocationCallback invocationCallback, String itemName, JRuleMemberOf memberOf,
+            Optional<JRuleConditionContext> conditionContext, List<JRulePreconditionContext> preconditionContextList,
+            Duration timedLock, Duration delayed) {
+        super(uid, logName, loggingTags, invocationCallback, preconditionContextList, timedLock, delayed);
         this.itemName = itemName;
         this.memberOf = memberOf;
         this.conditionContext = conditionContext;

--- a/src/main/java/org/openhab/automation/jrule/internal/engine/excutioncontext/JRuleItemReceivedCommandExecutionContext.java
+++ b/src/main/java/org/openhab/automation/jrule/internal/engine/excutioncontext/JRuleItemReceivedCommandExecutionContext.java
@@ -12,15 +12,14 @@
  */
 package org.openhab.automation.jrule.internal.engine.excutioncontext;
 
-import java.lang.reflect.Method;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
+import org.openhab.automation.jrule.internal.engine.JRuleInvocationCallback;
 import org.openhab.automation.jrule.internal.handler.JRuleEventHandler;
 import org.openhab.automation.jrule.items.JRuleItem;
-import org.openhab.automation.jrule.rules.JRule;
 import org.openhab.automation.jrule.rules.JRuleMemberOf;
 import org.openhab.automation.jrule.rules.event.JRuleEvent;
 import org.openhab.automation.jrule.rules.event.JRuleItemEvent;
@@ -39,12 +38,12 @@ public class JRuleItemReceivedCommandExecutionContext extends JRuleItemExecution
     private static final Logger log = LoggerFactory.getLogger(JRuleItemReceivedCommandExecutionContext.class);
     protected final Optional<String> command;
 
-    public JRuleItemReceivedCommandExecutionContext(JRule jRule, String logName, String[] loggingTags, Method method,
-            String itemName, JRuleMemberOf memberOf, Optional<JRuleConditionContext> conditionContext,
-            List<JRulePreconditionContext> preconditionContextList, Optional<String> command, Duration timedLock,
-            Duration delayed) {
-        super(jRule, logName, loggingTags, method, itemName, memberOf, conditionContext, preconditionContextList,
-                timedLock, delayed);
+    public JRuleItemReceivedCommandExecutionContext(String uid, String logName, String[] loggingTags,
+            JRuleInvocationCallback invocationCallback, String itemName, JRuleMemberOf memberOf,
+            Optional<JRuleConditionContext> conditionContext, List<JRulePreconditionContext> preconditionContextList,
+            Optional<String> command, Duration timedLock, Duration delayed) {
+        super(uid, logName, loggingTags, invocationCallback, itemName, memberOf, conditionContext,
+                preconditionContextList, timedLock, delayed);
         this.command = command;
     }
 
@@ -96,7 +95,7 @@ public class JRuleItemReceivedCommandExecutionContext extends JRuleItemExecution
     public String toString() {
         return "JRuleItemReceivedCommandExecutionContext{" + "command=" + command + ", itemName='" + itemName + '\''
                 + ", memberOf=" + memberOf + ", conditionContext=" + conditionContext + ", logName='" + logName + '\''
-                + ", jRule=" + rule + ", method=" + method + ", loggingTags=" + Arrays.toString(loggingTags)
-                + ", preconditionContextList=" + preconditionContextList + '}';
+                + ", uid=" + uid + ", invocationCallback=" + invocationCallback + ", loggingTags="
+                + Arrays.toString(loggingTags) + ", preconditionContextList=" + preconditionContextList + '}';
     }
 }

--- a/src/main/java/org/openhab/automation/jrule/internal/engine/excutioncontext/JRuleItemReceivedUpdateExecutionContext.java
+++ b/src/main/java/org/openhab/automation/jrule/internal/engine/excutioncontext/JRuleItemReceivedUpdateExecutionContext.java
@@ -12,15 +12,14 @@
  */
 package org.openhab.automation.jrule.internal.engine.excutioncontext;
 
-import java.lang.reflect.Method;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
+import org.openhab.automation.jrule.internal.engine.JRuleInvocationCallback;
 import org.openhab.automation.jrule.internal.handler.JRuleEventHandler;
 import org.openhab.automation.jrule.items.JRuleItem;
-import org.openhab.automation.jrule.rules.JRule;
 import org.openhab.automation.jrule.rules.JRuleMemberOf;
 import org.openhab.automation.jrule.rules.event.JRuleEvent;
 import org.openhab.automation.jrule.rules.event.JRuleItemEvent;
@@ -39,12 +38,12 @@ public class JRuleItemReceivedUpdateExecutionContext extends JRuleItemExecutionC
     private final Logger log = LoggerFactory.getLogger(JRuleItemReceivedUpdateExecutionContext.class);
     private final Optional<String> state;
 
-    public JRuleItemReceivedUpdateExecutionContext(JRule jRule, String logName, String[] loggingTags, Method method,
-            String itemName, JRuleMemberOf memberOf, Optional<JRuleConditionContext> conditionContext,
-            List<JRulePreconditionContext> preconditionContextList, Optional<String> state, Duration timedLock,
-            Duration delayed) {
-        super(jRule, logName, loggingTags, method, itemName, memberOf, conditionContext, preconditionContextList,
-                timedLock, delayed);
+    public JRuleItemReceivedUpdateExecutionContext(String uid, String logName, String[] loggingTags,
+            JRuleInvocationCallback invocationCallback, String itemName, JRuleMemberOf memberOf,
+            Optional<JRuleConditionContext> conditionContext, List<JRulePreconditionContext> preconditionContextList,
+            Optional<String> state, Duration timedLock, Duration delayed) {
+        super(uid, logName, loggingTags, invocationCallback, itemName, memberOf, conditionContext,
+                preconditionContextList, timedLock, delayed);
         this.state = state;
     }
 
@@ -98,7 +97,7 @@ public class JRuleItemReceivedUpdateExecutionContext extends JRuleItemExecutionC
     public String toString() {
         return "JRuleItemReceivedUpdateExecutionContext{" + "state=" + state + ", itemName='" + itemName + '\''
                 + ", memberOf=" + memberOf + ", conditionContext=" + conditionContext + ", logName='" + logName + '\''
-                + ", jRule=" + rule + ", method=" + method + ", loggingTags=" + Arrays.toString(loggingTags)
-                + ", preconditionContextList=" + preconditionContextList + '}';
+                + ", uid=" + uid + ", invocationCallback=" + invocationCallback + ", loggingTags="
+                + Arrays.toString(loggingTags) + ", preconditionContextList=" + preconditionContextList + '}';
     }
 }

--- a/src/main/java/org/openhab/automation/jrule/internal/engine/excutioncontext/JRuleLocalTimerExecutionContext.java
+++ b/src/main/java/org/openhab/automation/jrule/internal/engine/excutioncontext/JRuleLocalTimerExecutionContext.java
@@ -27,8 +27,8 @@ public class JRuleLocalTimerExecutionContext extends JRuleExecutionContext {
     private String timerName;
 
     public JRuleLocalTimerExecutionContext(JRuleExecutionContext parentContext, String timerName) {
-        super(parentContext.getRule(), parentContext.getLogName(), parentContext.getLoggingTags(),
-                parentContext.getMethod(), parentContext.getPreconditionContextList(), null, null);
+        super(parentContext.getUid(), parentContext.getLogName(), parentContext.getLoggingTags(),
+                parentContext.getInvocationCallback(), parentContext.getPreconditionContextList(), null, null);
         this.parentContext = parentContext;
         this.timerName = timerName;
     }

--- a/src/main/java/org/openhab/automation/jrule/internal/engine/excutioncontext/JRuleThingExecutionContext.java
+++ b/src/main/java/org/openhab/automation/jrule/internal/engine/excutioncontext/JRuleThingExecutionContext.java
@@ -12,13 +12,12 @@
  */
 package org.openhab.automation.jrule.internal.engine.excutioncontext;
 
-import java.lang.reflect.Method;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
-import org.openhab.automation.jrule.rules.JRule;
+import org.openhab.automation.jrule.internal.engine.JRuleInvocationCallback;
 import org.openhab.automation.jrule.rules.event.JRuleEvent;
 import org.openhab.automation.jrule.rules.event.JRuleThingEvent;
 import org.openhab.automation.jrule.things.JRuleThingStatus;
@@ -35,10 +34,11 @@ public class JRuleThingExecutionContext extends JRuleExecutionContext {
     private final Optional<JRuleThingStatus> from;
     private final Optional<JRuleThingStatus> to;
 
-    public JRuleThingExecutionContext(JRule jRule, String logName, String[] loggingTags, Method method,
-            Optional<String> thing, Optional<JRuleThingStatus> from, Optional<JRuleThingStatus> to,
-            List<JRulePreconditionContext> preconditions, Duration timedLock, Duration delayed) {
-        super(jRule, logName, loggingTags, method, preconditions, timedLock, delayed);
+    public JRuleThingExecutionContext(String uid, String logName, String[] loggingTags,
+            JRuleInvocationCallback invocationCallback, Optional<String> thing, Optional<JRuleThingStatus> from,
+            Optional<JRuleThingStatus> to, List<JRulePreconditionContext> preconditions, Duration timedLock,
+            Duration delayed) {
+        super(uid, logName, loggingTags, invocationCallback, preconditions, timedLock, delayed);
         this.thing = thing;
         this.from = from;
         this.to = to;
@@ -71,7 +71,7 @@ public class JRuleThingExecutionContext extends JRuleExecutionContext {
     @Override
     public String toString() {
         return "JRuleThingExecutionContext{" + "thing=" + thing + ", from=" + from + ", to=" + to + ", logName='"
-                + logName + '\'' + ", jRule=" + rule + ", method=" + method + ", loggingTags="
+                + logName + '\'' + ", uid=" + uid + ", invocationCallback=" + invocationCallback + ", loggingTags="
                 + Arrays.toString(loggingTags) + ", preconditionContextList=" + preconditionContextList + '}';
     }
 }

--- a/src/main/java/org/openhab/automation/jrule/internal/engine/excutioncontext/JRuleTimeTimerExecutionContext.java
+++ b/src/main/java/org/openhab/automation/jrule/internal/engine/excutioncontext/JRuleTimeTimerExecutionContext.java
@@ -12,12 +12,11 @@
  */
 package org.openhab.automation.jrule.internal.engine.excutioncontext;
 
-import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
-import org.openhab.automation.jrule.rules.JRule;
+import org.openhab.automation.jrule.internal.engine.JRuleInvocationCallback;
 import org.openhab.automation.jrule.rules.event.JRuleEvent;
 import org.openhab.automation.jrule.rules.event.JRuleTimerEvent;
 import org.openhab.core.events.AbstractEvent;
@@ -32,10 +31,10 @@ public class JRuleTimeTimerExecutionContext extends JRuleTimedExecutionContext {
     private final Optional<Integer> minute;
     private final Optional<Integer> second;
 
-    public JRuleTimeTimerExecutionContext(JRule jRule, String logName, String[] loggingTags, Method method,
-            List<JRulePreconditionContext> preconditionContextList, Optional<Integer> hour, Optional<Integer> minute,
-            Optional<Integer> second) {
-        super(jRule, logName, loggingTags, method, preconditionContextList);
+    public JRuleTimeTimerExecutionContext(String uid, String logName, String[] loggingTags,
+            JRuleInvocationCallback invocationCallback, List<JRulePreconditionContext> preconditionContextList,
+            Optional<Integer> hour, Optional<Integer> minute, Optional<Integer> second) {
+        super(uid, logName, loggingTags, invocationCallback, preconditionContextList);
         this.hour = hour;
         this.minute = minute;
         this.second = second;
@@ -66,7 +65,8 @@ public class JRuleTimeTimerExecutionContext extends JRuleTimedExecutionContext {
     @Override
     public String toString() {
         return "JRuleTimeTimerExecutionContext{" + "hour=" + hour + ", minute=" + minute + ", second=" + second
-                + ", logName='" + logName + '\'' + ", jRule=" + rule + ", method=" + method + ", loggingTags="
-                + Arrays.toString(loggingTags) + ", preconditionContextList=" + preconditionContextList + '}';
+                + ", logName='" + logName + '\'' + ", uid=" + uid + ", invocationCallback=" + invocationCallback
+                + ", loggingTags=" + Arrays.toString(loggingTags) + ", preconditionContextList="
+                + preconditionContextList + '}';
     }
 }

--- a/src/main/java/org/openhab/automation/jrule/internal/engine/excutioncontext/JRuleTimedCronExecutionContext.java
+++ b/src/main/java/org/openhab/automation/jrule/internal/engine/excutioncontext/JRuleTimedCronExecutionContext.java
@@ -12,11 +12,10 @@
  */
 package org.openhab.automation.jrule.internal.engine.excutioncontext;
 
-import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.List;
 
-import org.openhab.automation.jrule.rules.JRule;
+import org.openhab.automation.jrule.internal.engine.JRuleInvocationCallback;
 import org.openhab.automation.jrule.rules.event.JRuleEvent;
 import org.openhab.automation.jrule.rules.event.JRuleTimerEvent;
 import org.openhab.core.events.AbstractEvent;
@@ -29,9 +28,10 @@ import org.openhab.core.events.AbstractEvent;
 public class JRuleTimedCronExecutionContext extends JRuleTimedExecutionContext {
     private final String cron;
 
-    public JRuleTimedCronExecutionContext(JRule jRule, String logName, String[] loggingTags, Method method,
-            List<JRulePreconditionContext> preconditionContextList, String cron) {
-        super(jRule, logName, loggingTags, method, preconditionContextList);
+    public JRuleTimedCronExecutionContext(String uid, String logName, String[] loggingTags,
+            JRuleInvocationCallback invocationCallback, List<JRulePreconditionContext> preconditionContextList,
+            String cron) {
+        super(uid, logName, loggingTags, invocationCallback, preconditionContextList);
         this.cron = cron;
     }
 
@@ -51,8 +51,8 @@ public class JRuleTimedCronExecutionContext extends JRuleTimedExecutionContext {
 
     @Override
     public String toString() {
-        return "JRuleTimedCronExecutionContext{" + "cron='" + cron + '\'' + ", logName='" + logName + '\'' + ", jRule="
-                + rule + ", method=" + method + ", loggingTags=" + Arrays.toString(loggingTags)
+        return "JRuleTimedCronExecutionContext{" + "cron='" + cron + '\'' + ", logName='" + logName + '\'' + ", uid="
+                + uid + ", invocationCallback=" + invocationCallback + ", loggingTags=" + Arrays.toString(loggingTags)
                 + ", preconditionContextList=" + preconditionContextList + '}';
     }
 }

--- a/src/main/java/org/openhab/automation/jrule/internal/engine/excutioncontext/JRuleTimedExecutionContext.java
+++ b/src/main/java/org/openhab/automation/jrule/internal/engine/excutioncontext/JRuleTimedExecutionContext.java
@@ -12,10 +12,9 @@
  */
 package org.openhab.automation.jrule.internal.engine.excutioncontext;
 
-import java.lang.reflect.Method;
 import java.util.List;
 
-import org.openhab.automation.jrule.rules.JRule;
+import org.openhab.automation.jrule.internal.engine.JRuleInvocationCallback;
 
 /**
  * The {@link JRuleTimedExecutionContext}
@@ -23,8 +22,8 @@ import org.openhab.automation.jrule.rules.JRule;
  * @author Robert Delbrück - Initial contribution
  */
 public abstract class JRuleTimedExecutionContext extends JRuleExecutionContext {
-    public JRuleTimedExecutionContext(JRule jRule, String logName, String[] loggingTags, Method method,
-            List<JRulePreconditionContext> preconditionContextList) {
-        super(jRule, logName, loggingTags, method, preconditionContextList, null, null);
+    public JRuleTimedExecutionContext(String uid, String logName, String[] loggingTags,
+            JRuleInvocationCallback invocationCallback, List<JRulePreconditionContext> preconditionContextList) {
+        super(uid, logName, loggingTags, invocationCallback, preconditionContextList, null, null);
     }
 }

--- a/src/main/java/org/openhab/automation/jrule/internal/handler/JRuleTimerHandler.java
+++ b/src/main/java/org/openhab/automation/jrule/internal/handler/JRuleTimerHandler.java
@@ -169,17 +169,15 @@ public class JRuleTimerHandler {
     private void invokeTimerInternal(JRuleTimer timer, Consumer<JRuleTimer> runnable) {
         try {
             JRule.JRULE_EXECUTION_CONTEXT.set(new JRuleLocalTimerExecutionContext(timer.context, timer.name));
-            JRuleLog.debug(logger, timer.context.getMethod().getName(), "Invoking timer from context: {}",
-                    timer.context);
+            JRuleLog.debug(logger, timer.context.getLogName(), "Invoking timer from context: {}", timer.context);
 
-            JRuleLog.debug(logger, timer.context.getMethod().getName(), "setting mdc tags: {}",
-                    timer.context.getLoggingTags());
-            MDC.put(JRuleEngine.MDC_KEY_RULE, timer.context.getMethod().getName());
+            JRuleLog.debug(logger, timer.context.getLogName(), "setting mdc tags: {}", timer.context.getLoggingTags());
+            MDC.put(JRuleEngine.MDC_KEY_RULE, timer.context.getLogName());
             MDC.put(JRuleEngine.MDC_KEY_TIMER, timer.name);
             Arrays.stream(timer.context.getLoggingTags()).forEach(s -> MDC.put(s, s));
             runnable.accept(timer);
         } catch (IllegalArgumentException | SecurityException e) {
-            JRuleLog.error(logger, timer.context.getMethod().getName(), "Error {}", ExceptionUtils.getStackTrace(e));
+            JRuleLog.error(logger, timer.context.getLogName(), "Error {}", ExceptionUtils.getStackTrace(e));
         } finally {
             Arrays.stream(timer.context.getLoggingTags()).forEach(MDC::remove);
             MDC.remove(JRuleEngine.MDC_KEY_RULE);

--- a/src/main/java/org/openhab/automation/jrule/internal/module/JRuleModuleEntry.java
+++ b/src/main/java/org/openhab/automation/jrule/internal/module/JRuleModuleEntry.java
@@ -58,8 +58,8 @@ public class JRuleModuleEntry extends SimpleRule {
 
     boolean enabled = false;
 
-    public JRuleModuleEntry(JRule jRule, Method method, String ruleName) {
-        this.uid = createUid(jRule, method);
+    public JRuleModuleEntry(String uid, String ruleName) {
+        this.uid = uid;
         tags.add("JRule");
         setTriggers(ruleTriggers);
         setConditions(List.of());
@@ -143,6 +143,13 @@ public class JRuleModuleEntry extends SimpleRule {
         TriggerBuilder triggerBuilder = TriggerBuilder.create().withId("" + (triggerCounter++))
                 .withTypeUID(JRuleModuleUtil.toTriggerModuleUID(JRuleWhenTimeTrigger.class));
         ruleTriggers.add(triggerBuilder.build());
+    }
+
+    public void addJRuleWhenStartupTrigger(JRuleExecutionContext context) {
+        executionContextList.add(context);
+        // TriggerBuilder triggerBuilder = TriggerBuilder.create().withId("" + (triggerCounter++))
+        // .withTypeUID(JRuleModuleUtil.toTriggerModuleUID(JRuleWhenTimeTrigger.class));
+        // ruleTriggers.add(triggerBuilder.build());
     }
 
     public void addJRuleWhenThingTrigger(JRuleExecutionContext context) {

--- a/src/main/java/org/openhab/automation/jrule/internal/module/JRuleRuleProvider.java
+++ b/src/main/java/org/openhab/automation/jrule/internal/module/JRuleRuleProvider.java
@@ -12,7 +12,6 @@
  */
 package org.openhab.automation.jrule.internal.module;
 
-import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Map;
@@ -21,7 +20,7 @@ import java.util.stream.Collectors;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
-import org.openhab.automation.jrule.rules.JRule;
+import org.openhab.automation.jrule.internal.engine.excutioncontext.JRuleExecutionContext;
 import org.openhab.core.automation.Rule;
 import org.openhab.core.automation.RuleProvider;
 import org.openhab.core.automation.RuleStatus;
@@ -95,17 +94,15 @@ public class JRuleRuleProvider implements RuleProvider {
         return rules.get(ruleUid);
     }
 
-    public void runRule(JRule rule, Method method) {
+    public void runRule(JRuleExecutionContext context) {
         RuleStatusInfoEvent ruleStatusInfoEvent = JRuleEventFactory.createRuleStatusInfoEvent(
-                new RuleStatusInfo(RuleStatus.RUNNING, RuleStatusDetail.NONE, null),
-                JRuleModuleEntry.createUid(rule, method), "jRule");
+                new RuleStatusInfo(RuleStatus.RUNNING, RuleStatusDetail.NONE, null), context.getUid(), "jRule");
         eventPublisher.post(ruleStatusInfoEvent);
     }
 
-    public void stopRule(JRule rule, Method method) {
+    public void stopRule(JRuleExecutionContext context) {
         RuleStatusInfoEvent ruleStatusInfoEvent = JRuleEventFactory.createRuleStatusInfoEvent(
-                new RuleStatusInfo(RuleStatus.IDLE, RuleStatusDetail.NONE, null),
-                JRuleModuleEntry.createUid(rule, method), "jRule");
+                new RuleStatusInfo(RuleStatus.IDLE, RuleStatusDetail.NONE, null), context.getUid(), "jRule");
         eventPublisher.post(ruleStatusInfoEvent);
     }
 }

--- a/src/test/java/org/openhab/automation/jrule/internal/engine/JRuleBuilderTest.java
+++ b/src/test/java/org/openhab/automation/jrule/internal/engine/JRuleBuilderTest.java
@@ -1,0 +1,316 @@
+/**
+ * Copyright (c) 2010-2023 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.automation.jrule.internal.engine;
+
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.time.Duration;
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.openhab.automation.jrule.internal.engine.JRuleBuilder.Condition;
+import org.openhab.automation.jrule.internal.engine.excutioncontext.JRuleChannelExecutionContext;
+import org.openhab.automation.jrule.internal.engine.excutioncontext.JRuleItemChangeExecutionContext;
+import org.openhab.automation.jrule.internal.engine.excutioncontext.JRuleItemReceivedCommandExecutionContext;
+import org.openhab.automation.jrule.internal.engine.excutioncontext.JRuleItemReceivedUpdateExecutionContext;
+import org.openhab.automation.jrule.internal.engine.excutioncontext.JRuleThingExecutionContext;
+import org.openhab.automation.jrule.internal.engine.excutioncontext.JRuleTimeTimerExecutionContext;
+import org.openhab.automation.jrule.internal.engine.excutioncontext.JRuleTimedCronExecutionContext;
+import org.openhab.automation.jrule.internal.module.JRuleRuleProvider;
+import org.openhab.automation.jrule.internal.rules.JRuleAbstractTest;
+import org.openhab.automation.jrule.rules.JRuleMemberOf;
+import org.openhab.automation.jrule.things.JRuleThingStatus;
+import org.openhab.core.scheduler.CronScheduler;
+
+/**
+ * The {@link JRuleBuilderTest}
+ *
+ *
+ * @author Rüdiger Sopp - Initial contribution
+ */
+public class JRuleBuilderTest extends JRuleAbstractTest {
+
+    JRuleEngine jRuleEngine;
+    JRuleRuleProvider ruleProvider;
+    CronScheduler cronScheduler;
+    JRuleInvocationCallback invocationCallback = event -> {
+    };
+
+    JRuleBuilder jRuleBuilder;
+
+    Pattern UUID_REGEX = Pattern
+            .compile("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$");
+
+    @BeforeEach
+    public void setup() {
+        jRuleEngine = Mockito.spy(JRuleEngine.class);
+        ruleProvider = Mockito.mock(JRuleRuleProvider.class);
+        cronScheduler = Mockito.mock(CronScheduler.class);
+        jRuleEngine.setRuleProvider(ruleProvider);
+        jRuleEngine.setCronScheduler(cronScheduler);
+
+        jRuleBuilder = new JRuleBuilder(jRuleEngine, "ruleName", invocationCallback);
+    }
+
+    @Test
+    void testEmptyRule() {
+
+        boolean result = jRuleBuilder.build();
+
+        Assertions.assertFalse(result);
+        verify(jRuleEngine, never()).addToContext(null, false);
+        verify(ruleProvider, times(1)).add(argThat(entry -> UUID_REGEX.matcher(entry.getUID()).matches()
+                && "ruleName".equals(entry.getName()) && entry.getTriggers().isEmpty()));
+    }
+
+    @Test
+    void testUid() {
+
+        boolean result = jRuleBuilder.uid("uid").build();
+
+        Assertions.assertFalse(result);
+        verify(jRuleEngine, never()).addToContext(null, false);
+        verify(ruleProvider, times(1)).add(argThat(entry -> "uid".equals(entry.getUID())
+                && "ruleName".equals(entry.getName()) && entry.getTriggers().isEmpty()));
+    }
+
+    @Test
+    public void testDefaultProperties() {
+
+        boolean result = jRuleBuilder.uid("uid").whenItemReceivedCommand("item", null, null, null).build();
+
+        Assertions.assertTrue(result);
+        verify(jRuleEngine, times(1)).addToContext(argThat(context -> context != null && !context.isEnabled()
+                && invocationCallback.equals(context.getInvocationCallback()) && "ruleName".equals(context.getLogName())
+                && context.getLoggingTags() == JRuleEngine.EMPTY_LOG_TAGS && context.getTimedLock() == null
+                && context.getPreconditionContextList().isEmpty() && context.getDelayed() == null), eq(false));
+        verify(ruleProvider, times(1)).add(argThat(entry -> entry.getTriggers().size() == 1));
+    }
+
+    @Test
+    public void testPropertyEnabled() {
+
+        boolean result = jRuleBuilder.uid("uid").whenItemReceivedCommand("item", null, null, null).enableRule(true)
+                .build();
+
+        Assertions.assertTrue(result);
+        verify(jRuleEngine, times(1)).addToContext(argThat(context -> context != null && context.isEnabled()
+                && "ruleName".equals(context.getLogName()) && context.getLoggingTags() == JRuleEngine.EMPTY_LOG_TAGS
+                && context.getTimedLock() == null && context.getDelayed() == null), eq(true));
+        verify(ruleProvider, times(1)).add(argThat(entry -> entry.getTriggers().size() == 1));
+    }
+
+    @Test
+    public void testPropertyLogName() {
+
+        boolean result = jRuleBuilder.uid("uid").whenItemReceivedCommand("item", null, null, null).logName("logName")
+                .build();
+
+        Assertions.assertTrue(result);
+        verify(jRuleEngine, times(1)).addToContext(argThat(context -> context != null && !context.isEnabled()
+                && "logName".equals(context.getLogName()) && context.getLoggingTags() == JRuleEngine.EMPTY_LOG_TAGS
+                && context.getTimedLock() == null && context.getDelayed() == null), eq(false));
+        verify(ruleProvider, times(1)).add(argThat(entry -> entry.getTriggers().size() == 1));
+    }
+
+    @Test
+    public void testPropertyLoggingTags() {
+
+        String[] loggingTags = new String[] { "A", "B", "C" };
+
+        boolean result = jRuleBuilder.uid("uid").whenItemReceivedCommand("item", null, null, null)
+                .loggingTags(loggingTags).build();
+
+        Assertions.assertTrue(result);
+        verify(jRuleEngine, times(1)).addToContext(argThat(context -> context != null && !context.isEnabled()
+                && "ruleName".equals(context.getLogName()) && context.getLoggingTags() == loggingTags
+                && context.getTimedLock() == null && context.getDelayed() == null), eq(false));
+        verify(ruleProvider, times(1)).add(argThat(entry -> entry.getTriggers().size() == 1));
+    }
+
+    @Test
+    public void testPropertyTimedLock() {
+
+        boolean result = jRuleBuilder.uid("uid").whenItemReceivedCommand("item", null, null, null)
+                .timedLock(Duration.ofSeconds(2)).build();
+
+        Assertions.assertTrue(result);
+        verify(jRuleEngine, times(1)).addToContext(
+                argThat(context -> context != null && !context.isEnabled() && "ruleName".equals(context.getLogName())
+                        && context.getLoggingTags() == JRuleEngine.EMPTY_LOG_TAGS
+                        && Duration.ofSeconds(2).equals(context.getTimedLock()) && context.getDelayed() == null),
+                eq(false));
+        verify(ruleProvider, times(1)).add(argThat(entry -> entry.getTriggers().size() == 1));
+    }
+
+    @Test
+    public void testPropertyDelayed() {
+
+        boolean result = jRuleBuilder.uid("uid").whenItemReceivedCommand("item", null, null, null)
+                .delayed(Duration.ofSeconds(3)).build();
+
+        Assertions.assertTrue(result);
+        verify(jRuleEngine, times(1)).addToContext(argThat(context -> context != null && !context.isEnabled()
+                && "ruleName".equals(context.getLogName()) && context.getLoggingTags() == JRuleEngine.EMPTY_LOG_TAGS
+                && context.getTimedLock() == null && Duration.ofSeconds(3).equals(context.getDelayed())), eq(false));
+        verify(ruleProvider, times(1)).add(argThat(entry -> entry.getTriggers().size() == 1));
+    }
+
+    @Test
+    public void testPreconditions() {
+
+        boolean result = jRuleBuilder.uid("uid")
+                .preCondition("empty", new Condition(null, null, null, null, null, null))
+                .preCondition("abc", new Condition(0.1, 0.2, 0.3, 0.4, "e", "n"))
+                .preCondition("def", new Condition(0.5, 0.6, 0.7, 0.8, "1", "2"))
+                .whenItemReceivedCommand("item", null, null, null).build();
+
+        Assertions.assertTrue(result);
+        verify(jRuleEngine, times(1)).addToContext(
+                argThat(context -> context != null && !context.isEnabled() && "ruleName".equals(context.getLogName())
+                        && context.getLoggingTags() == JRuleEngine.EMPTY_LOG_TAGS && context.getTimedLock() == null
+                        && context.getDelayed() == null && context.getPreconditionContextList().size() == 3
+                        && context.getPreconditionContextList().stream()
+                                .anyMatch(c -> c.getItem().equals("empty") && c.getLt().isEmpty()
+                                        && c.getLte().isEmpty() && c.getGt().isEmpty() && c.getGte().isEmpty()
+                                        && c.getEq().isEmpty() && c.getNeq().isEmpty())
+                        && context.getPreconditionContextList().stream()
+                                .anyMatch(c -> c.getItem().equals("abc") && c.getLt().orElse(0.0).equals(0.1)
+                                        && c.getLte().orElse(0.0).equals(0.2) && c.getGt().orElse(0.0).equals(0.3)
+                                        && c.getGte().orElse(0.0).equals(0.4) && c.getEq().orElse("").equals("e")
+                                        && c.getNeq().orElse("").equals("n"))
+                        && context.getPreconditionContextList().stream()
+                                .anyMatch(c -> c.getItem().equals("def") && c.getLt().orElse(0.0).equals(0.5)
+                                        && c.getLte().orElse(0.0).equals(0.6) && c.getGt().orElse(0.0).equals(0.7)
+                                        && c.getGte().orElse(0.0).equals(0.8) && c.getEq().orElse("").equals("1")
+                                        && c.getNeq().orElse("").equals("2"))),
+                eq(false));
+        verify(ruleProvider, times(1)).add(argThat(entry -> entry.getTriggers().size() == 1));
+    }
+
+    @Test
+    public void testWhenThingTrigger() {
+
+        boolean result = jRuleBuilder.whenThingTrigger("thing", null, null)
+                .whenThingTrigger("thing", JRuleThingStatus.INITIALIZING, JRuleThingStatus.ONLINE).build();
+
+        Assertions.assertTrue(result);
+        verify(jRuleEngine, times(2)).addToContext(isA(JRuleThingExecutionContext.class), eq(false));
+        verify(ruleProvider, times(1)).add(argThat(entry -> entry.getTriggers().size() == 2));
+    }
+
+    @Test
+    public void testWhenChannelTrigger() {
+
+        boolean result = jRuleBuilder.whenChannelTrigger("channel1", null).whenChannelTrigger("channel2", "event")
+                .build();
+
+        Assertions.assertTrue(result);
+        verify(jRuleEngine, times(1))
+                .addToContext(argThat(context -> context instanceof JRuleChannelExecutionContext channelExecutionContext
+                        && "channel1".equals(channelExecutionContext.getChannel())
+                        && channelExecutionContext.getEvent().isEmpty()), eq(false));
+        verify(jRuleEngine, times(1))
+                .addToContext(argThat(context -> context instanceof JRuleChannelExecutionContext channelExecutionContext
+                        && "channel2".equals(channelExecutionContext.getChannel())
+                        && "event".equals(channelExecutionContext.getEvent().orElse(null))), eq(false));
+        verify(ruleProvider, times(1)).add(argThat(entry -> entry.getTriggers().size() == 2));
+    }
+
+    @Test
+    public void testWhenItemReceivedCommand() {
+
+        boolean result = jRuleBuilder.whenItemReceivedCommand("item", JRuleMemberOf.None, null, null)
+                .whenItemReceivedCommand("item", JRuleMemberOf.All, "command", null).build();
+
+        Assertions.assertTrue(result);
+        verify(jRuleEngine, times(2)).addToContext(isA(JRuleItemReceivedCommandExecutionContext.class), eq(false));
+        verify(ruleProvider, times(1)).add(argThat(entry -> entry.getTriggers().size() == 2));
+    }
+
+    @Test
+    public void testWhenItemChanged() {
+
+        boolean result = jRuleBuilder.whenItemChange("item", JRuleMemberOf.None, null, "to", null, null)
+                .whenItemChange("item", JRuleMemberOf.All, "from", null, null, null).build();
+
+        Assertions.assertTrue(result);
+        verify(jRuleEngine, times(2)).addToContext(isA(JRuleItemChangeExecutionContext.class), eq(false));
+        verify(ruleProvider, times(1)).add(argThat(entry -> entry.getTriggers().size() == 2));
+    }
+
+    @Test
+    public void testWhenItemReceivedUpdate() {
+
+        boolean result = jRuleBuilder.whenItemReceivedUpdate("item", JRuleMemberOf.None, "state", null)
+                .whenItemReceivedUpdate("item", JRuleMemberOf.All, "command", null).build();
+
+        Assertions.assertTrue(result);
+        verify(jRuleEngine, times(2)).addToContext(isA(JRuleItemReceivedUpdateExecutionContext.class), eq(false));
+        verify(ruleProvider, times(1)).add(argThat(entry -> entry.getTriggers().size() == 2));
+    }
+
+    @Test
+    public void testWhenCronTrigger() {
+
+        boolean result = jRuleBuilder.whenCronTrigger("abcde").build();
+
+        Assertions.assertTrue(result);
+        verify(jRuleEngine, times(1)).addToContext(
+                argThat(context -> context instanceof JRuleTimedCronExecutionContext timedCronExecutionContext
+                        && timedCronExecutionContext.getCron().equals("abcde")),
+                eq(false));
+        verify(ruleProvider, times(1)).add(argThat(entry -> entry.getTriggers().size() == 1));
+    }
+
+    @Test
+    public void testWhenTimeTrigger() {
+
+        boolean result = jRuleBuilder.whenTimeTrigger(null, null, null).whenTimeTrigger(12, 34, 56).build();
+
+        Assertions.assertTrue(result);
+        verify(jRuleEngine, times(1)).addToContext(
+                argThat(context -> context instanceof JRuleTimeTimerExecutionContext timeTimerExecutionContext
+                        && timeTimerExecutionContext.getHour().isEmpty()
+                        && timeTimerExecutionContext.getMinute().isEmpty()
+                        && timeTimerExecutionContext.getSecond().isEmpty()),
+                eq(false));
+        verify(jRuleEngine, times(1)).addToContext(
+                argThat(context -> context instanceof JRuleTimeTimerExecutionContext timeTimerExecutionContext
+                        && timeTimerExecutionContext.getHour().orElse(0) == 12
+                        && timeTimerExecutionContext.getMinute().orElse(0) == 34
+                        && timeTimerExecutionContext.getSecond().orElse(0) == 56),
+                eq(false));
+        verify(ruleProvider, times(1)).add(argThat(entry -> entry.getTriggers().size() == 2));
+    }
+
+    @Test
+    public void testCondition() {
+        Condition condition = new Condition(0.1, 0.2, 0.3, 0.4, "eq", "neq");
+
+        Assertions.assertEquals(0.1, condition.lt());
+        Assertions.assertEquals(0.2, condition.lte());
+        Assertions.assertEquals(0.3, condition.gt());
+        Assertions.assertEquals(0.4, condition.gte());
+        Assertions.assertEquals("eq", condition.eq());
+        Assertions.assertEquals("neq", condition.neq());
+    }
+}


### PR DESCRIPTION
### Support for dynamic rules using a newly created JRuleBuilder

* Added JRuleInvocationCallback which is a functional interface that allows to call a anonymous function instead of a predefined method.
* Rule execution refactored, so that it is based on new JRuleInvocationCallback instead of JRule/method.
* Contexts, JRuleModuleEntry, etc. use callback instead of JRule and method.
* Annotation processing in JRuleEngine internally uses JRuleBuilder as well. Method-call is wrapped inside a callback. Behaviour is compatible to existing implementation - no changes needed in existing rule projects
* Rule-uids:
   - Dynamic rules use a random uuid by default (can be over-written using JRuleBuilder::uid()).
   - Static rules set a uid compatible with the existing naming scheme (name.method)
* Added Example (43) to show a simple usage of the new JRuleBuilder
