### PR TITLE
add option to overwrite metadata

### DIFF
--- a/src/main/java/org/openhab/automation/jrule/internal/items/JRuleInternalItem.java
+++ b/src/main/java/org/openhab/automation/jrule/internal/items/JRuleInternalItem.java
@@ -86,8 +86,8 @@ public abstract class JRuleInternalItem implements JRuleItem {
     }
 
     @Override
-    public void addMetadata(String namespace, JRuleItemMetadata metadata) {
-        this.metadataRegistry.addMetadata(namespace, name, metadata);
+    public void addMetadata(String namespace, JRuleItemMetadata metadata, boolean override) {
+        this.metadataRegistry.addMetadata(namespace, name, metadata, override);
     }
 
     @Override

--- a/src/main/java/org/openhab/automation/jrule/items/JRuleItem.java
+++ b/src/main/java/org/openhab/automation/jrule/items/JRuleItem.java
@@ -49,7 +49,7 @@ public interface JRuleItem {
     @NonNullByDefault
     Map<String, JRuleItemMetadata> getMetadata();
 
-    void addMetadata(String namespace, JRuleItemMetadata metadata);
+    void addMetadata(String namespace, JRuleItemMetadata metadata, boolean override);
 
     @NonNullByDefault
     List<String> getTags();

--- a/src/main/java/org/openhab/automation/jrule/items/metadata/JRuleMetadataRegistry.java
+++ b/src/main/java/org/openhab/automation/jrule/items/metadata/JRuleMetadataRegistry.java
@@ -41,8 +41,13 @@ public class JRuleMetadataRegistry {
                         metadata -> new JRuleItemMetadata(metadata.getValue(), metadata.getConfiguration())));
     }
 
-    public void addMetadata(String namespace, String itemName, JRuleItemMetadata metadata) {
-        metadataRegistry.add(
-                new Metadata(new MetadataKey(namespace, itemName), metadata.getValue(), metadata.getConfiguration()));
+    public void addMetadata(String namespace, String itemName, JRuleItemMetadata metadata, boolean override) {
+        MetadataKey key = new MetadataKey(namespace, itemName);
+        Metadata foundMetadata = metadataRegistry.get(key);
+        if (foundMetadata != null && override) {
+            metadataRegistry.remove(key);
+        }
+
+        metadataRegistry.add(new Metadata(key, metadata.getValue(), metadata.getConfiguration()));
     }
 }

--- a/src/test/java/org/openhab/automation/jrule/items/JRuleItemTestBase.java
+++ b/src/test/java/org/openhab/automation/jrule/items/JRuleItemTestBase.java
@@ -132,7 +132,7 @@ public abstract class JRuleItemTestBase {
     @Test
     public void testGetMetadata() {
         JRuleItem item = getJRuleItem();
-        Assertions.assertEquals(1, item.getMetadata().size());
+        Assertions.assertEquals(2, item.getMetadata().size());
         Assertions.assertEquals("SetLightState", item.getMetadata().get("Speech").getValue());
         Assertions.assertEquals(1, item.getMetadata().get("Speech").getConfiguration().size());
         Assertions.assertEquals("Livingroom", item.getMetadata().get("Speech").getConfiguration().get("location"));

--- a/src/test/java/org/openhab/automation/jrule/items/JRuleItemTestBase.java
+++ b/src/test/java/org/openhab/automation/jrule/items/JRuleItemTestBase.java
@@ -53,6 +53,8 @@ public abstract class JRuleItemTestBase {
     public static final String ITEM_NAME_2 = "Name2";
     public static final String GROUP_NAME_2 = "Group2";
     public static final String SUB_ITEM_NAME = "NameSub";
+    public static final String METADATA_WHAT_S_THE_TIME = "what's the time";
+    public static final String METADATA_VOICE_SYSTEM = "voiceSystem";
 
     protected EventPublisher eventPublisher;
 
@@ -104,7 +106,8 @@ public abstract class JRuleItemTestBase {
         JRuleItemRegistry.setMetadataRegistry(metadataRegistry);
 
         Mockito.when(mock.getAllMetadata(Mockito.anyString()))
-                .thenReturn(Map.of("Speech", new JRuleItemMetadata("SetLightState", Map.of("location", "Livingroom"))));
+                .thenReturn(Map.of("Speech", new JRuleItemMetadata("SetLightState", Map.of("location", "Livingroom")),
+                        METADATA_VOICE_SYSTEM, new JRuleItemMetadata(METADATA_WHAT_S_THE_TIME)));
     }
 
     protected abstract JRuleItem getJRuleItem();
@@ -138,7 +141,15 @@ public abstract class JRuleItemTestBase {
     @Test
     public void testAddMetadata() {
         JRuleItem item = getJRuleItem();
-        item.addMetadata("voiceSystem", new JRuleItemMetadata("what's the time"));
+        item.addMetadata(METADATA_VOICE_SYSTEM, new JRuleItemMetadata(METADATA_WHAT_S_THE_TIME), false);
+        Assertions.assertEquals(METADATA_WHAT_S_THE_TIME, item.getMetadata().get(METADATA_VOICE_SYSTEM).getValue());
+
+        item.addMetadata(METADATA_VOICE_SYSTEM, new JRuleItemMetadata("something else"), false);
+        Assertions.assertEquals(METADATA_WHAT_S_THE_TIME, item.getMetadata().get(METADATA_VOICE_SYSTEM).getValue());
+
+        // not handled by the mock, therefor it's ok here
+        item.addMetadata(METADATA_VOICE_SYSTEM, new JRuleItemMetadata("something else"), true);
+        Assertions.assertEquals(METADATA_WHAT_S_THE_TIME, item.getMetadata().get(METADATA_VOICE_SYSTEM).getValue());
     }
 
     @Test

--- a/src/test/java/org/openhab/automation/jrule/rules/user/TestRules.java
+++ b/src/test/java/org/openhab/automation/jrule/rules/user/TestRules.java
@@ -391,7 +391,7 @@ public class TestRules extends JRule {
         logInfo("Metadata Configuration: '{}'", item.getMetadata().get("Speech").getConfiguration());
 
         // add something new and check it
-        item.addMetadata("VoiceSystem", new JRuleItemMetadata("myNewValue", Map.of("mykey", "myvalue")));
+        item.addMetadata("VoiceSystem", new JRuleItemMetadata("myNewValue", Map.of("mykey", "myvalue")), false);
         logInfo("Metadata: '{}'", item.getMetadata());
         logInfo("Metadata Value: '{}'", item.getMetadata().get("VoiceSystem").getValue());
         logInfo("Metadata Configuration: '{}'", item.getMetadata().get("VoiceSystem").getConfiguration());


### PR DESCRIPTION
currently if there is already metadata for the given key it happens nothing, with the 'override' option you can delete and create aka override the previous one.