### PR TITLE
Also catch Errors, not just exceptions

### DIFF
--- a/src/main/java/org/openhab/automation/jrule/internal/handler/JRuleHandler.java
+++ b/src/main/java/org/openhab/automation/jrule/internal/handler/JRuleHandler.java
@@ -282,9 +282,7 @@ public class JRuleHandler implements PropertyChangeListener {
             cls.getDeclaredConstructor().newInstance();
             logger.info("Instantiated JRuleItems class");
         } catch (ClassNotFoundException | IllegalAccessException | NoSuchMethodException | InstantiationException
-                | InvocationTargetException e) {
-            logger.error("Could not instantiate JRuleItems file", e);
-        } catch (Error e) {
+                | InvocationTargetException | Error e) {
             logger.error("Could not instantiate JRuleItems file", e);
         }
 
@@ -293,11 +291,9 @@ public class JRuleHandler implements PropertyChangeListener {
             Class<?> cls = Class.forName(config.getGeneratedThingPackage() + ".JRuleThings", true, loader);
             cls.getDeclaredConstructor().newInstance();
             logger.info("Instantiated JRuleThings class");
-        } catch (ClassNotFoundException | IllegalAccessException | NoSuchMethodException | InstantiationException
-                | InvocationTargetException e) {
+        } catch (ClassNotFoundException | IllegalAccessException | NoSuchMethodException | InstantiationException |
+                 InvocationTargetException | Error e) {
             logger.error("Could not instantiate JRuleThings file", e);
-        } catch (Error error) {
-            logger.error("Could not instantiate JRuleThings file", error);
         }
 
         // Reload Actions class - this will also instantiate all actions
@@ -305,11 +301,9 @@ public class JRuleHandler implements PropertyChangeListener {
             Class<?> cls = Class.forName(config.getGeneratedActionPackage() + ".JRuleActions", true, loader);
             cls.getDeclaredConstructor().newInstance();
             logger.info("Instantiated JRuleActions class");
-        } catch (ClassNotFoundException | IllegalAccessException | NoSuchMethodException | InstantiationException
-                | InvocationTargetException e) {
+        } catch (ClassNotFoundException | IllegalAccessException | NoSuchMethodException | InstantiationException |
+                 InvocationTargetException | Error e) {
             logger.error("Could not instantiate JRuleActions file", e);
-        } catch (Error error) {
-            logger.error("Could not instantiate JRuleActions file", error);
         }
 
         // Load rules that refer to the items

--- a/src/main/java/org/openhab/automation/jrule/internal/handler/JRuleHandler.java
+++ b/src/main/java/org/openhab/automation/jrule/internal/handler/JRuleHandler.java
@@ -284,6 +284,8 @@ public class JRuleHandler implements PropertyChangeListener {
         } catch (ClassNotFoundException | IllegalAccessException | NoSuchMethodException | InstantiationException
                 | InvocationTargetException e) {
             logger.error("Could not instantiate JRuleItems file", e);
+        } catch (Error e) {
+            logger.error("Could not instantiate JRuleItems file", e);
         }
 
         // Reload Things class - this will also instantiate all things and load them to the registry
@@ -294,6 +296,8 @@ public class JRuleHandler implements PropertyChangeListener {
         } catch (ClassNotFoundException | IllegalAccessException | NoSuchMethodException | InstantiationException
                 | InvocationTargetException e) {
             logger.error("Could not instantiate JRuleThings file", e);
+        } catch (Error error) {
+            logger.error("Could not instantiate JRuleThings file", error);
         }
 
         // Reload Actions class - this will also instantiate all actions
@@ -304,6 +308,8 @@ public class JRuleHandler implements PropertyChangeListener {
         } catch (ClassNotFoundException | IllegalAccessException | NoSuchMethodException | InstantiationException
                 | InvocationTargetException e) {
             logger.error("Could not instantiate JRuleActions file", e);
+        } catch (Error error) {
+            logger.error("Could not instantiate JRuleActions file", error);
         }
 
         // Load rules that refer to the items

--- a/src/main/java/org/openhab/automation/jrule/internal/handler/JRuleHandler.java
+++ b/src/main/java/org/openhab/automation/jrule/internal/handler/JRuleHandler.java
@@ -291,8 +291,8 @@ public class JRuleHandler implements PropertyChangeListener {
             Class<?> cls = Class.forName(config.getGeneratedThingPackage() + ".JRuleThings", true, loader);
             cls.getDeclaredConstructor().newInstance();
             logger.info("Instantiated JRuleThings class");
-        } catch (ClassNotFoundException | IllegalAccessException | NoSuchMethodException | InstantiationException |
-                 InvocationTargetException | Error e) {
+        } catch (ClassNotFoundException | IllegalAccessException | NoSuchMethodException | InstantiationException
+                | InvocationTargetException | Error e) {
             logger.error("Could not instantiate JRuleThings file", e);
         }
 
@@ -301,8 +301,8 @@ public class JRuleHandler implements PropertyChangeListener {
             Class<?> cls = Class.forName(config.getGeneratedActionPackage() + ".JRuleActions", true, loader);
             cls.getDeclaredConstructor().newInstance();
             logger.info("Instantiated JRuleActions class");
-        } catch (ClassNotFoundException | IllegalAccessException | NoSuchMethodException | InstantiationException |
-                 InvocationTargetException | Error e) {
+        } catch (ClassNotFoundException | IllegalAccessException | NoSuchMethodException | InstantiationException
+                | InvocationTargetException | Error e) {
             logger.error("Could not instantiate JRuleActions file", e);
         }
 


### PR DESCRIPTION
Realized java.lang.Error may be thrown here, but not caught, causing silent hanging of jrule.