### PR TITLE
Make it possible to see thing channels and linked items

### DIFF
--- a/doc/EXAMPLES.md
+++ b/doc/EXAMPLES.md
@@ -45,6 +45,7 @@
     + [Example 41 - Get Metadata and Tags](#example-41---get-metadata-and-tags)
     + [Example 42 - Persist future data](#example-42---persist-future-data)
     + [Example 43 - Creating a rule dynamically using JRuleBuilder](#example-43---creating-a-rule-dynamically-using-jrulebuilder)
+    + [Example 44 - Setting items linked to a thing to UNDEF when thing goes offline](#example-44---setting-items-linked-to-a-thing-to-undef-when-thing-goes-offline)
 
 ### Example 1 - Invoke another item Switch from rule
 
@@ -1123,5 +1124,36 @@ public class DynamicRuleModule extends JRule {
                 .whenItemChange("MyItem", JRuleMemberOf.None, "OFF", "ON", null, null)
                 .build();
     }
+}
+```
+
+## Example 44 - Setting items linked to a thing to UNDEF when thing goes offline
+
+Use case: No longer be fooled by outdated item states when a thing goes offline
+
+```java
+package org.openhab.automation.jrule.rules.user;
+
+import java.util.List;
+
+import org.openhab.automation.jrule.items.JRuleItem;
+import org.openhab.automation.jrule.rules.JRule;
+import org.openhab.automation.jrule.rules.JRuleName;
+import org.openhab.automation.jrule.rules.JRuleWhenThingTrigger;
+import org.openhab.automation.jrule.rules.event.JRuleThingEvent;
+import org.openhab.automation.jrule.things.JRuleAbstractThing;
+import org.openhab.automation.jrule.things.JRuleChannel;
+import org.openhab.automation.jrule.things.JRuleThingRegistry;
+import org.openhab.automation.jrule.things.JRuleThingStatus;
+
+public class ChannelsToUndefWhenTingOffline extends JRule {
+  @JRuleName("Device monitoring - Set linked items to UNDEF if thing goes offline")
+  @JRuleWhenThingTrigger(thing = "*", from = JRuleThingStatus.ONLINE)
+  public void setChannelsToUndefWhenThingOffline(JRuleThingEvent thingEvent) {
+    String thingUID = thingEvent.getThing();
+    JRuleAbstractThing thing = JRuleThingRegistry.get(thingUID, JRuleAbstractThing.class);
+    List<JRuleChannel> channels = thing.getChannels();
+    channels.forEach(channel -> thing.getLinkedItems(channel).forEach(JRuleItem::postUndefUpdate));
+  }
 }
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,7 @@
   <version>4.2.1-SNAPSHOT</version>
 
   <properties>
+    <testcontainers.version>1.20.4</testcontainers.version>
     <bnd.importpackage>com.sun.org.apache.xml.internal.utils.*;resolution:=optional,\
       com.sun.org.apache.xpath.internal.*;resolution:=optional,\
       org.apache.log.*;resolution:=optional,\
@@ -77,19 +78,19 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>junit-jupiter</artifactId>
-      <version>1.17.6</version>
+      <version>${testcontainers.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>toxiproxy</artifactId>
-      <version>1.17.6</version>
+      <version>${testcontainers.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>mockserver</artifactId>
-      <version>1.17.6</version>
+      <version>${testcontainers.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/history/dependencies.xml
+++ b/src/main/history/dependencies.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<features xmlns="http://karaf.apache.org/xmlns/features/v1.6.0" name="org.openhab.automation.jrule-4.2.0">
+<features xmlns="http://karaf.apache.org/xmlns/features/v1.6.0" name="org.openhab.automation.jrule-4.2.1-SNAPSHOT">
     <feature version="0.0.0">
         <feature>openhab-runtime-base</feature>
         <feature>wrap</feature>
         <bundle>mvn:javax.el/javax.el-api/2.2.4</bundle>
         <bundle>mvn:org.freemarker/freemarker/2.3.32</bundle>
-        <bundle>mvn:org.openhab.addons.bundles/org.openhab.automation.jrule/4.2.0</bundle>
+        <bundle>mvn:org.openhab.addons.bundles/org.openhab.automation.jrule/4.2.1-SNAPSHOT</bundle>
         <bundle>wrap:mvn:javax.servlet/jsp-api/2.0</bundle>
         <bundle>wrap:mvn:javax.servlet/servlet-api/2.4</bundle>
         <bundle>wrap:mvn:org.lastnpe.eea/eea-all/2.2.1</bundle>

--- a/src/main/java/org/openhab/automation/jrule/internal/handler/JRuleEventHandler.java
+++ b/src/main/java/org/openhab/automation/jrule/internal/handler/JRuleEventHandler.java
@@ -143,6 +143,14 @@ public class JRuleEventHandler {
         }
     }
 
+    public void postUndef(String itemName) {
+        postUpdate(itemName, UnDefType.UNDEF);
+    }
+
+    public void postNull(String itemName) {
+        postUpdate(itemName, UnDefType.NULL);
+    }
+
     public void postUpdate(String itemName, double value, String unit) {
         QuantityType<?> type = new QuantityType<>(value + " " + unit);
         postUpdate(itemName, type);

--- a/src/main/java/org/openhab/automation/jrule/internal/handler/JRuleHandler.java
+++ b/src/main/java/org/openhab/automation/jrule/internal/handler/JRuleHandler.java
@@ -158,6 +158,7 @@ public class JRuleHandler implements PropertyChangeListener {
         final JRuleThingHandler thingHandler = JRuleThingHandler.get();
         thingHandler.setThingManager(thingManager);
         thingHandler.setThingRegistry(thingRegistry);
+        thingHandler.setItemChannelLinkRegistry(itemChannelLinkRegistry);
 
         final JRuleItemHandler itemHandler = JRuleItemHandler.get();
         itemHandler.setItemRegistry(itemRegistry);

--- a/src/main/java/org/openhab/automation/jrule/internal/handler/JRuleThingHandler.java
+++ b/src/main/java/org/openhab/automation/jrule/internal/handler/JRuleThingHandler.java
@@ -13,12 +13,16 @@
 package org.openhab.automation.jrule.internal.handler;
 
 import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
+import org.openhab.automation.jrule.items.JRuleItem;
+import org.openhab.automation.jrule.items.JRuleItemRegistry;
+import org.openhab.automation.jrule.things.JRuleChannel;
 import org.openhab.automation.jrule.things.JRuleThingStatus;
-import org.openhab.core.thing.Thing;
-import org.openhab.core.thing.ThingManager;
-import org.openhab.core.thing.ThingRegistry;
-import org.openhab.core.thing.ThingUID;
+import org.openhab.core.thing.*;
+import org.openhab.core.thing.link.ItemChannelLinkRegistry;
 
 /**
  * The {@link JRuleThingHandler} provides access to thing actions
@@ -36,12 +40,18 @@ public class JRuleThingHandler {
 
     private ThingManager thingManager;
 
+    private ItemChannelLinkRegistry itemChannelLinkRegistry;
+
     public void setThingManager(ThingManager thingManager) {
         this.thingManager = thingManager;
     }
 
     public void setThingRegistry(ThingRegistry thingRegistry) {
         this.thingRegistry = thingRegistry;
+    }
+
+    public void setItemChannelLinkRegistry(ItemChannelLinkRegistry itemChannelLinkRegistry) {
+        this.itemChannelLinkRegistry = itemChannelLinkRegistry;
     }
 
     public static JRuleThingHandler get() {
@@ -82,5 +92,25 @@ public class JRuleThingHandler {
         } else {
             return JRuleThingStatus.THING_UNKNOWN;
         }
+    }
+
+    /**
+     * Get all channels of a thing
+     * 
+     * @param thingUID the thing UID
+     * @return list of all channels
+     */
+    public List<JRuleChannel> getChannels(String thingUID) {
+        Thing thing = thingRegistry.get(new ThingUID(thingUID));
+        if (thing != null) {
+            return thing.getChannels().stream().map(channel -> new JRuleChannel(channel.getUID().toString())).toList();
+        } else {
+            return List.of();
+        }
+    }
+
+    public Set<JRuleItem> getLinkedItems(JRuleChannel channel) {
+        return itemChannelLinkRegistry.getLinkedItemNames(new ChannelUID(channel.getChannelUID())).stream()
+                .map(itemName -> JRuleItemRegistry.get(itemName)).collect(Collectors.toSet());
     }
 }

--- a/src/main/java/org/openhab/automation/jrule/items/JRuleItem.java
+++ b/src/main/java/org/openhab/automation/jrule/items/JRuleItem.java
@@ -97,7 +97,11 @@ public interface JRuleItem extends JRulePersistence {
     }
 
     default void postNullUpdate() {
-        JRuleEventHandler.get().postUpdate(getName(), null);
+        JRuleEventHandler.get().postNull(getName());
+    }
+
+    default void postUndefUpdate() {
+        JRuleEventHandler.get().postUndef(getName());
     }
 
     default boolean isGroup() {

--- a/src/main/java/org/openhab/automation/jrule/things/JRuleAbstractThing.java
+++ b/src/main/java/org/openhab/automation/jrule/things/JRuleAbstractThing.java
@@ -12,7 +12,11 @@
  */
 package org.openhab.automation.jrule.things;
 
+import java.util.List;
+import java.util.Set;
+
 import org.openhab.automation.jrule.internal.handler.JRuleThingHandler;
+import org.openhab.automation.jrule.items.JRuleItem;
 
 /**
  * The {@link JRuleAbstractThing} represents a thing that is either a bridge, a bridged (sub thing of a bridge) or a
@@ -48,5 +52,13 @@ public abstract class JRuleAbstractThing {
     public void restart() {
         disable();
         enable();
+    }
+
+    public List<JRuleChannel> getChannels() {
+        return JRuleThingHandler.get().getChannels(thingUID);
+    }
+
+    public Set<JRuleItem> getLinkedItems(JRuleChannel channel) {
+        return JRuleThingHandler.get().getLinkedItems(channel);
     }
 }

--- a/src/main/java/org/openhab/automation/jrule/things/JRuleChannel.java
+++ b/src/main/java/org/openhab/automation/jrule/things/JRuleChannel.java
@@ -1,0 +1,13 @@
+package org.openhab.automation.jrule.things;
+
+public class JRuleChannel {
+    private String channelUID;
+
+    public JRuleChannel(String channelUID) {
+        this.channelUID = channelUID;
+    }
+
+    public String getChannelUID() {
+        return channelUID;
+    }
+}

--- a/src/main/java/org/openhab/automation/jrule/things/JRuleChannel.java
+++ b/src/main/java/org/openhab/automation/jrule/things/JRuleChannel.java
@@ -1,5 +1,22 @@
+/**
+ * Copyright (c) 2010-2023 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.openhab.automation.jrule.things;
 
+/**
+ * The {@link JRuleChannel} represents a Thing channel, possibly linked to an Item.
+ *
+ * @author Arne Seime - Initial contribution
+ */
 public class JRuleChannel {
     private String channelUID;
 

--- a/src/test/java/org/openhab/automation/jrule/rules/integration_test/JRuleITBase.java
+++ b/src/test/java/org/openhab/automation/jrule/rules/integration_test/JRuleITBase.java
@@ -312,7 +312,7 @@ public abstract class JRuleITBase {
         return Optional.ofNullable(getState(itemName)).map(Double::parseDouble);
     }
 
-    private String getState(String itemName) throws IOException, ParseException {
+    protected static String getState(String itemName) throws IOException, ParseException {
         try (CloseableHttpClient client = HttpClientBuilder.create().build()) {
             HttpGet request = new HttpGet(String.format("http://%s:%s/rest/items/" + itemName + "/state",
                     getOpenhabHost(), getOpenhabPort()));

--- a/src/test/resources/docker/conf/items/default.items
+++ b/src/test/resources/docker/conf/items/default.items
@@ -87,3 +87,5 @@ Number          Number_To_Persist_Future   (InfluxDbPersist)
 
 
 Dimmer          Dimmer_With_Tags_And_Metadata   ["Control", "Light"]	{ Speech="SetLightState" [ location="Livingroom" ] }
+
+Number ItemToUndef {channel="mqtt:topic:mqtt:fromonlinetest:number"}

--- a/src/test/resources/docker/conf/things/mqtt.things
+++ b/src/test/resources/docker/conf/things/mqtt.things
@@ -5,4 +5,8 @@ Bridge mqtt:broker:mqtt [ host="mqtt", port=8666, username="admin", password="ad
 		Type number : number [ stateTopic="number/state" ]
 		Type number : numberTrigger [ stateTopic="number/state", trigger="true" ]
 	}
+	Thing topic fromonlinetest {
+		Channels:
+		Type number : number [ stateTopic="fromonlinetest/state" ]
+	}
 }


### PR DESCRIPTION
Use case: set items to UNDEF when a thing goes offline.