### PR TITLE
Rule inheritance

### DIFF
--- a/src/main/java/org/openhab/automation/jrule/internal/engine/JRuleEngine.java
+++ b/src/main/java/org/openhab/automation/jrule/internal/engine/JRuleEngine.java
@@ -122,7 +122,7 @@ public class JRuleEngine implements PropertyChangeListener {
         logDebug("Adding rule: {}, enabled: {}", jRule, enableRule);
         ruleLoadingStatistics.addRuleClass();
         Arrays.stream(jRule.getClass().getDeclaredMethods()).filter(method -> !method.getName().startsWith("lambda$"))
-                .filter(method -> method.getDeclaringClass().equals(jRule.getClass())) // Skip inherited methods
+                .filter(method -> method.isAnnotationPresent(JRuleName.class))
                 .forEach(method -> this.add(method, jRule, enableRule));
     }
 
@@ -138,12 +138,6 @@ public class JRuleEngine implements PropertyChangeListener {
 
     private void add(Method method, JRule jRule, boolean enableRule) {
         logDebug("Adding rule method: {}", method.getName());
-
-        if (!method.isAnnotationPresent(JRuleName.class)) {
-            logDebug("Skipping method {} on class {} since JRuleName annotation is missing", method.getName(),
-                    jRule.getClass().getName());
-            return;
-        }
 
         // Check if method is public, else execution will fail at runtime
         boolean isPublic = (method.getModifiers() & Modifier.PUBLIC) != 0;

--- a/src/main/java/org/openhab/automation/jrule/internal/engine/JRuleEngine.java
+++ b/src/main/java/org/openhab/automation/jrule/internal/engine/JRuleEngine.java
@@ -121,7 +121,7 @@ public class JRuleEngine implements PropertyChangeListener {
     public void add(JRule jRule, boolean enableRule) {
         logDebug("Adding rule: {}, enabled: {}", jRule, enableRule);
         ruleLoadingStatistics.addRuleClass();
-        Arrays.stream(jRule.getClass().getDeclaredMethods()).filter(method -> !method.getName().startsWith("lambda$"))
+        Arrays.stream(jRule.getClass().getMethods()).filter(method -> !method.getName().startsWith("lambda$"))
                 .filter(method -> method.isAnnotationPresent(JRuleName.class))
                 .forEach(method -> this.add(method, jRule, enableRule));
     }

--- a/src/main/java/org/openhab/automation/jrule/rules/JRuleCondition.java
+++ b/src/main/java/org/openhab/automation/jrule/rules/JRuleCondition.java
@@ -12,11 +12,14 @@
  */
 package org.openhab.automation.jrule.rules;
 
+import java.lang.annotation.Inherited;
+
 /**
  * The {@link JRuleCondition}
  *
  * @author Robert Delbrück
  */
+@Inherited
 public @interface JRuleCondition {
     double gt() default Double.MIN_VALUE;
 

--- a/src/main/java/org/openhab/automation/jrule/rules/JRuleDebounce.java
+++ b/src/main/java/org/openhab/automation/jrule/rules/JRuleDebounce.java
@@ -12,10 +12,7 @@
  */
 package org.openhab.automation.jrule.rules;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+import java.lang.annotation.*;
 import java.time.temporal.ChronoUnit;
 
 /**
@@ -24,6 +21,7 @@ import java.time.temporal.ChronoUnit;
  *
  * @author Robert Delbrück - Initial contribution
  */
+@Inherited
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.METHOD })
 public @interface JRuleDebounce {

--- a/src/main/java/org/openhab/automation/jrule/rules/JRuleDelayed.java
+++ b/src/main/java/org/openhab/automation/jrule/rules/JRuleDelayed.java
@@ -12,10 +12,7 @@
  */
 package org.openhab.automation.jrule.rules;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+import java.lang.annotation.*;
 import java.time.temporal.ChronoUnit;
 
 /**
@@ -24,6 +21,7 @@ import java.time.temporal.ChronoUnit;
  *
  * @author Robert Delbrück - Initial contribution
  */
+@Inherited
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.METHOD })
 public @interface JRuleDelayed {

--- a/src/main/java/org/openhab/automation/jrule/rules/JRuleLogName.java
+++ b/src/main/java/org/openhab/automation/jrule/rules/JRuleLogName.java
@@ -12,16 +12,14 @@
  */
 package org.openhab.automation.jrule.rules;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+import java.lang.annotation.*;
 
 /**
  * The {@link JRuleLogName}
  *
  * @author Joseph (Seaside) Hagberg - Initial contribution
  */
+@Inherited
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.METHOD })
 public @interface JRuleLogName {

--- a/src/main/java/org/openhab/automation/jrule/rules/JRuleName.java
+++ b/src/main/java/org/openhab/automation/jrule/rules/JRuleName.java
@@ -12,16 +12,14 @@
  */
 package org.openhab.automation.jrule.rules;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+import java.lang.annotation.*;
 
 /**
  * The {@link JRuleName}
  *
  * @author Joseph (Seaside) Hagberg - Initial contribution
  */
+@Inherited
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.METHOD })
 public @interface JRuleName {

--- a/src/main/java/org/openhab/automation/jrule/rules/JRulePrecondition.java
+++ b/src/main/java/org/openhab/automation/jrule/rules/JRulePrecondition.java
@@ -12,17 +12,14 @@
  */
 package org.openhab.automation.jrule.rules;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Repeatable;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+import java.lang.annotation.*;
 
 /**
  * The {@link JRulePrecondition}
  *
  * @author Arne Seime- Initial contribution
  */
+@Inherited
 @Repeatable(JRulePreconditions.class)
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.METHOD })

--- a/src/main/java/org/openhab/automation/jrule/rules/JRulePreconditions.java
+++ b/src/main/java/org/openhab/automation/jrule/rules/JRulePreconditions.java
@@ -12,16 +12,14 @@
  */
 package org.openhab.automation.jrule.rules;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+import java.lang.annotation.*;
 
 /**
  * The {@link JRulePreconditions}
  *
  * @author Arne Seime- Initial contribution
  */
+@Inherited
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.METHOD })
 public @interface JRulePreconditions {

--- a/src/main/java/org/openhab/automation/jrule/rules/JRuleTag.java
+++ b/src/main/java/org/openhab/automation/jrule/rules/JRuleTag.java
@@ -12,16 +12,14 @@
  */
 package org.openhab.automation.jrule.rules;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+import java.lang.annotation.*;
 
 /**
  * The {@link JRuleTag}
  *
  * @author Robert Delbrück
  */
+@Inherited
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.METHOD })
 public @interface JRuleTag {

--- a/src/main/java/org/openhab/automation/jrule/rules/JRuleWhenChannelTrigger.java
+++ b/src/main/java/org/openhab/automation/jrule/rules/JRuleWhenChannelTrigger.java
@@ -12,17 +12,14 @@
  */
 package org.openhab.automation.jrule.rules;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Repeatable;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+import java.lang.annotation.*;
 
 /**
  * The {@link JRuleWhenChannelTriggers}
  *
  * @author Robert Delbrück
  */
+@Inherited
 @Repeatable(JRuleWhenChannelTriggers.class)
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.METHOD })

--- a/src/main/java/org/openhab/automation/jrule/rules/JRuleWhenChannelTriggers.java
+++ b/src/main/java/org/openhab/automation/jrule/rules/JRuleWhenChannelTriggers.java
@@ -12,16 +12,14 @@
  */
 package org.openhab.automation.jrule.rules;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+import java.lang.annotation.*;
 
 /**
  * The {@link JRuleWhenChannelTriggers}
  *
  * @author Robert Delbrück
  */
+@Inherited
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.METHOD })
 public @interface JRuleWhenChannelTriggers {

--- a/src/main/java/org/openhab/automation/jrule/rules/JRuleWhenCronTrigger.java
+++ b/src/main/java/org/openhab/automation/jrule/rules/JRuleWhenCronTrigger.java
@@ -12,17 +12,14 @@
  */
 package org.openhab.automation.jrule.rules;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Repeatable;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+import java.lang.annotation.*;
 
 /**
  * The {@link JRuleWhenCronTriggers}
  *
  * @author Robert Delbrück
  */
+@Inherited
 @Repeatable(JRuleWhenCronTriggers.class)
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.METHOD })

--- a/src/main/java/org/openhab/automation/jrule/rules/JRuleWhenCronTriggers.java
+++ b/src/main/java/org/openhab/automation/jrule/rules/JRuleWhenCronTriggers.java
@@ -12,16 +12,14 @@
  */
 package org.openhab.automation.jrule.rules;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+import java.lang.annotation.*;
 
 /**
  * The {@link JRuleWhenCronTriggers}
  *
  * @author Robert Delbrück
  */
+@Inherited
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.METHOD })
 public @interface JRuleWhenCronTriggers {

--- a/src/main/java/org/openhab/automation/jrule/rules/JRuleWhenItemChange.java
+++ b/src/main/java/org/openhab/automation/jrule/rules/JRuleWhenItemChange.java
@@ -12,17 +12,14 @@
  */
 package org.openhab.automation.jrule.rules;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Repeatable;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+import java.lang.annotation.*;
 
 /**
  * The {@link JRuleWhenItemChange}
  *
  * @author Robert Delbrück
  */
+@Inherited
 @Repeatable(JRuleWhenItemChanges.class)
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.METHOD })

--- a/src/main/java/org/openhab/automation/jrule/rules/JRuleWhenItemChanges.java
+++ b/src/main/java/org/openhab/automation/jrule/rules/JRuleWhenItemChanges.java
@@ -12,16 +12,14 @@
  */
 package org.openhab.automation.jrule.rules;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+import java.lang.annotation.*;
 
 /**
  * The {@link JRuleWhenItemChanges}
  *
  * @author Robert Delbrück
  */
+@Inherited
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.METHOD })
 public @interface JRuleWhenItemChanges {

--- a/src/main/java/org/openhab/automation/jrule/rules/JRuleWhenItemReceivedCommand.java
+++ b/src/main/java/org/openhab/automation/jrule/rules/JRuleWhenItemReceivedCommand.java
@@ -12,17 +12,14 @@
  */
 package org.openhab.automation.jrule.rules;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Repeatable;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+import java.lang.annotation.*;
 
 /**
  * The {@link JRuleWhenItemReceivedCommand}
  *
  * @author Robert Delbrück
  */
+@Inherited
 @Repeatable(JRuleWhenItemReceivedCommands.class)
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.METHOD })

--- a/src/main/java/org/openhab/automation/jrule/rules/JRuleWhenItemReceivedCommands.java
+++ b/src/main/java/org/openhab/automation/jrule/rules/JRuleWhenItemReceivedCommands.java
@@ -12,16 +12,14 @@
  */
 package org.openhab.automation.jrule.rules;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+import java.lang.annotation.*;
 
 /**
  * The {@link JRuleWhenItemReceivedCommands}
  *
  * @author Robert Delbrück
  */
+@Inherited
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.METHOD })
 public @interface JRuleWhenItemReceivedCommands {

--- a/src/main/java/org/openhab/automation/jrule/rules/JRuleWhenItemReceivedUpdate.java
+++ b/src/main/java/org/openhab/automation/jrule/rules/JRuleWhenItemReceivedUpdate.java
@@ -12,17 +12,14 @@
  */
 package org.openhab.automation.jrule.rules;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Repeatable;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+import java.lang.annotation.*;
 
 /**
  * The {@link JRuleWhenItemReceivedUpdate}
  *
  * @author Robert Delbrück
  */
+@Inherited
 @Repeatable(JRuleWhenItemReceivedUpdates.class)
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.METHOD })

--- a/src/main/java/org/openhab/automation/jrule/rules/JRuleWhenItemReceivedUpdates.java
+++ b/src/main/java/org/openhab/automation/jrule/rules/JRuleWhenItemReceivedUpdates.java
@@ -12,16 +12,14 @@
  */
 package org.openhab.automation.jrule.rules;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+import java.lang.annotation.*;
 
 /**
  * The {@link JRuleWhenItemReceivedUpdates}
  *
  * @author Robert Delbrück
  */
+@Inherited
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.METHOD })
 public @interface JRuleWhenItemReceivedUpdates {

--- a/src/main/java/org/openhab/automation/jrule/rules/JRuleWhenThingTrigger.java
+++ b/src/main/java/org/openhab/automation/jrule/rules/JRuleWhenThingTrigger.java
@@ -12,11 +12,7 @@
  */
 package org.openhab.automation.jrule.rules;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Repeatable;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+import java.lang.annotation.*;
 
 import org.openhab.automation.jrule.things.JRuleThingStatus;
 
@@ -25,6 +21,7 @@ import org.openhab.automation.jrule.things.JRuleThingStatus;
  *
  * @author Robert Delbrück
  */
+@Inherited
 @Repeatable(JRuleWhenThingTriggers.class)
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.METHOD })

--- a/src/main/java/org/openhab/automation/jrule/rules/JRuleWhenThingTriggers.java
+++ b/src/main/java/org/openhab/automation/jrule/rules/JRuleWhenThingTriggers.java
@@ -12,16 +12,14 @@
  */
 package org.openhab.automation.jrule.rules;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+import java.lang.annotation.*;
 
 /**
  * The {@link JRuleWhenThingTriggers}
  *
  * @author Robert Delbrück
  */
+@Inherited
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.METHOD })
 public @interface JRuleWhenThingTriggers {

--- a/src/main/java/org/openhab/automation/jrule/rules/JRuleWhenTimeTrigger.java
+++ b/src/main/java/org/openhab/automation/jrule/rules/JRuleWhenTimeTrigger.java
@@ -12,17 +12,14 @@
  */
 package org.openhab.automation.jrule.rules;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Repeatable;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+import java.lang.annotation.*;
 
 /**
  * The {@link JRuleWhenTimeTrigger}
  *
  * @author Robert Delbrück
  */
+@Inherited
 @Repeatable(JRuleWhenTimeTriggers.class)
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.METHOD })

--- a/src/main/java/org/openhab/automation/jrule/rules/JRuleWhenTimeTriggers.java
+++ b/src/main/java/org/openhab/automation/jrule/rules/JRuleWhenTimeTriggers.java
@@ -12,16 +12,14 @@
  */
 package org.openhab.automation.jrule.rules;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+import java.lang.annotation.*;
 
 /**
  * The {@link JRuleWhenTimeTriggers}
  *
  * @author Robert Delbrück
  */
+@Inherited
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.METHOD })
 public @interface JRuleWhenTimeTriggers {


### PR DESCRIPTION
Make it possible to define reusable rules in a parent class

Use case: Multiple installation sites where an abstract common rule class is extended by a concrete class (with possible parameters) for use in the specific installation sites.