### PR TITLE
WIP Send command/update only if different

### DIFF
--- a/src/main/history/dependencies.xml
+++ b/src/main/history/dependencies.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<features xmlns="http://karaf.apache.org/xmlns/features/v1.6.0" name="org.openhab.automation.jrule-4.2.0">
+<features xmlns="http://karaf.apache.org/xmlns/features/v1.6.0" name="org.openhab.automation.jrule-4.2.1-SNAPSHOT">
     <feature version="0.0.0">
         <feature>openhab-runtime-base</feature>
         <feature>wrap</feature>
         <bundle>mvn:javax.el/javax.el-api/2.2.4</bundle>
         <bundle>mvn:org.freemarker/freemarker/2.3.32</bundle>
-        <bundle>mvn:org.openhab.addons.bundles/org.openhab.automation.jrule/4.2.0</bundle>
+        <bundle>mvn:org.openhab.addons.bundles/org.openhab.automation.jrule/4.2.1-SNAPSHOT</bundle>
         <bundle>wrap:mvn:javax.servlet/jsp-api/2.0</bundle>
         <bundle>wrap:mvn:javax.servlet/servlet-api/2.4</bundle>
         <bundle>wrap:mvn:org.lastnpe.eea/eea-all/2.2.1</bundle>

--- a/src/main/java/org/openhab/automation/jrule/items/JRuleNumberItem.java
+++ b/src/main/java/org/openhab/automation/jrule/items/JRuleNumberItem.java
@@ -44,12 +44,34 @@ public interface JRuleNumberItem extends JRuleItem {
     }
 
     /**
+     * Sends a decimal command only if current state is different
+     *
+     * @param command command to send.
+     */
+    default void sendCommandIfDifferent(JRuleDecimalValue command) {
+        if(!command.equals(getState())) {
+            sendUncheckedCommand(command);
+        }
+    }
+
+    /**
      * Sends a decimal update
      * 
      * @param state update to send
      */
     default void postUpdate(JRuleDecimalValue state) {
         postUncheckedUpdate(state);
+    }
+
+    /**
+     * Sends a decimal update
+     *
+     * @param state update to send
+     */
+    default void postUpdateIfDifferent(JRuleDecimalValue state) {
+        if (!state.equals(getState())) {
+            postUncheckedUpdate(state);
+        }
     }
 
     /**
@@ -62,12 +84,30 @@ public interface JRuleNumberItem extends JRuleItem {
     }
 
     /**
+     * Sends a number command only if current state is different
+     *
+     * @param command as number via JRuleDecimalValue will be send.
+     */
+    default void sendCommandIfDifferent(double command) {
+        sendCommandIfDifferent(new JRuleDecimalValue(command));
+    }
+
+    /**
      * Sends a number command.
      *
      * @param command as number via JRuleDecimalValue will be send.
      */
     default void sendCommand(int command) {
         sendUncheckedCommand(new JRuleDecimalValue(command));
+    }
+
+    /**
+     * Sends a number command only if current state is different
+     *
+     * @param command as number via JRuleDecimalValue will be send.
+     */
+    default void sendCommandIfDifferent(int command) {
+        sendCommandIfDifferent(new JRuleDecimalValue(command));
     }
 
     /**
@@ -80,12 +120,30 @@ public interface JRuleNumberItem extends JRuleItem {
     }
 
     /**
+     * Sends a number update only if current state is different
+     *
+     * @param value as number via JRuleDecimalValue will be send.
+     */
+    default void postUpdateIfDifferent(double value) {
+        postUpdateIfDifferent(new JRuleDecimalValue(value));
+    }
+
+    /**
      * Sends a number update.
      *
      * @param state as number via JRuleDecimalValue will be send.
      */
     default void postUpdate(int state) {
         postUncheckedUpdate(new JRuleDecimalValue(state));
+    }
+
+    /**
+     * Sends a number update only if current state is different
+     *
+     * @param value as number via JRuleDecimalValue will be send.
+     */
+    default void postUpdateIfDifferent(int value) {
+        postUpdateIfDifferent(new JRuleDecimalValue(value));
     }
 
     default JRuleDecimalValue getStateAsDecimal() {

--- a/src/main/java/org/openhab/automation/jrule/items/JRuleNumberItem.java
+++ b/src/main/java/org/openhab/automation/jrule/items/JRuleNumberItem.java
@@ -49,7 +49,7 @@ public interface JRuleNumberItem extends JRuleItem {
      * @param command command to send.
      */
     default void sendCommandIfDifferent(JRuleDecimalValue command) {
-        if(!command.equals(getState())) {
+        if (!command.equals(getState())) {
             sendUncheckedCommand(command);
         }
     }

--- a/src/main/java/org/openhab/automation/jrule/items/JRuleQuantityItem.java
+++ b/src/main/java/org/openhab/automation/jrule/items/JRuleQuantityItem.java
@@ -14,6 +14,7 @@ package org.openhab.automation.jrule.items;
 
 import java.util.Optional;
 
+import org.eclipse.jdt.annotation.NonNull;
 import org.openhab.automation.jrule.exception.JRuleItemNotFoundException;
 import org.openhab.automation.jrule.internal.JRuleUtil;
 import org.openhab.automation.jrule.internal.handler.JRuleEventHandler;
@@ -40,8 +41,19 @@ public interface JRuleQuantityItem extends JRuleNumberItem {
      *
      * @param command command to send
      */
-    default void sendCommand(JRuleQuantityValue command) {
+    default void sendCommand(@NonNull JRuleQuantityValue command) {
         sendUncheckedCommand(command);
+    }
+
+    /**
+     * Sends a quantity command only if current state is different
+     *
+     * @param command command to send
+     */
+    default void sendCommandIfDifferent(@NonNull JRuleQuantityValue command) {
+        if(!command.equals(getState())) {
+            sendUncheckedCommand(command);
+        }
     }
 
     /**
@@ -49,8 +61,19 @@ public interface JRuleQuantityItem extends JRuleNumberItem {
      *
      * @param state state to send.
      */
-    default void postUpdate(JRuleQuantityValue state) {
+    default void postUpdate(@NonNull JRuleQuantityValue state) {
         postUncheckedUpdate(state);
+    }
+
+    /**
+     * Sends a quantity update only if current state is different
+     *
+     * @param state state to send.
+     */
+    default void postUpdateIfDifferent(@NonNull JRuleQuantityValue state) {
+        if(!state.equals(getState())) {
+            postUncheckedUpdate(state);
+        }
     }
 
     /**
@@ -64,6 +87,16 @@ public interface JRuleQuantityItem extends JRuleNumberItem {
     }
 
     /**
+     * Sends a number command with the given unit only if current state is different
+     *
+     * @param command as number via JRuleQuantityValue will be sent.
+     * @param unit of value as a string
+     */
+    default void sendCommandIfDifferent(double command, String unit) {
+        sendCommandIfDifferent(new JRuleQuantityValue(command, unit));
+    }
+
+    /**
      * Sends a number command with the given unit.
      *
      * @param state as number via JRuleQuantityValue will be sent.
@@ -71,6 +104,16 @@ public interface JRuleQuantityItem extends JRuleNumberItem {
      */
     default void postUpdate(double state, String unit) {
         postUncheckedUpdate(new JRuleQuantityValue(state, unit));
+    }
+
+    /**
+     * Sends a number uppdate with the given unit only if current state is different
+     *
+     * @param state as number via JRuleQuantityValue will be sent.
+     * @param unit of value as a string
+     */
+    default void postUpdateIfDifferent(double state, String unit) {
+        postUpdateIfDifferent(new JRuleQuantityValue(state, unit));
     }
 
     /**
@@ -84,6 +127,16 @@ public interface JRuleQuantityItem extends JRuleNumberItem {
     }
 
     /**
+     * Sends a number command with the given unit only if current state is different
+     *
+     * @param command as number via JRuleQuantityValue will be sent.
+     * @param unit of value as a string
+     */
+    default void sendCommandIfDifferent(int command, String unit) {
+        sendCommandIfDifferent(new JRuleQuantityValue(command, unit));
+    }
+
+    /**
      * Sends a number command with the given unit.
      *
      * @param state as number via JRuleQuantityValue will be sent.
@@ -91,6 +144,16 @@ public interface JRuleQuantityItem extends JRuleNumberItem {
      */
     default void postUpdate(int state, String unit) {
         postUncheckedUpdate(new JRuleQuantityValue(state, unit));
+    }
+
+    /**
+     * Sends a number command with the given unit only if current state is different
+     *
+     * @param state as number via JRuleQuantityValue will be sent.
+     * @param unit of value as a string
+     */
+    default void postUpdateIfDifferent(int state, String unit) {
+        postUpdateIfDifferent(new JRuleQuantityValue(state, unit));
     }
 
     /**
@@ -103,12 +166,34 @@ public interface JRuleQuantityItem extends JRuleNumberItem {
     }
 
     /**
+     * Sends a number command without any unit only if current state is different
+     *
+     * @param command as number via JRuleDecimalValue will be sent.
+     */
+    default void sendCommandIfDifferent(double command) {
+        if(getStateAsDecimal() != null && Math.abs(getStateAsDecimal().doubleValue() - command) < 0.0001) {
+            sendUncheckedCommand(new JRuleDecimalValue(command));
+        }
+    }
+
+    /**
      * Sends a number command without any unit.
      *
      * @param state as number via JRuleDecimalValue will be sent.
      */
     default void postUpdate(double state) {
         postUncheckedUpdate(new JRuleDecimalValue(state));
+    }
+
+    /**
+     * Sends a number command without any unit only if current state is different
+     *
+     * @param state as number via JRuleDecimalValue will be sent.
+     */
+    default void postUpdateIfDifferent(double state) {
+        if(getStateAsDecimal() != null && Math.abs(getStateAsDecimal().doubleValue() - state) < 0.0001) {
+            postUncheckedUpdate(new JRuleDecimalValue(state));
+        }
     }
 
     /**
@@ -121,12 +206,34 @@ public interface JRuleQuantityItem extends JRuleNumberItem {
     }
 
     /**
+     * Sends a number command without any unit only if current state is different
+     *
+     * @param command as number via JRuleDecimalValue will be sent.
+     */
+    default void sendCommandIfDifferent(int command) {
+        if(getStateAsDecimal() != null && Math.abs(getStateAsDecimal().doubleValue() - command) < 0.0001) {
+            sendUncheckedCommand(new JRuleDecimalValue(command));
+        }
+    }
+
+    /**
      * Sends a number command without any unit.
      *
      * @param state as number via JRuleDecimalValue will be sent.
      */
     default void postUpdate(int state) {
         postUncheckedUpdate(new JRuleDecimalValue(state));
+    }
+
+    /**
+     * Sends a number command without any unit.
+     *
+     * @param state as number via JRuleDecimalValue will be sent.
+     */
+    default void postUpdateIfDifferent(int state) {
+        if(getStateAsDecimal() != null && Math.abs(getStateAsDecimal().doubleValue() - state) < 0.0001) {
+            postUncheckedUpdate(new JRuleDecimalValue(state));
+        }
     }
 
     default JRuleDecimalValue getStateAsDecimal() {

--- a/src/main/java/org/openhab/automation/jrule/items/JRuleQuantityItem.java
+++ b/src/main/java/org/openhab/automation/jrule/items/JRuleQuantityItem.java
@@ -51,7 +51,7 @@ public interface JRuleQuantityItem extends JRuleNumberItem {
      * @param command command to send
      */
     default void sendCommandIfDifferent(@NonNull JRuleQuantityValue command) {
-        if(!command.equals(getState())) {
+        if (!command.equals(getState())) {
             sendUncheckedCommand(command);
         }
     }
@@ -71,7 +71,7 @@ public interface JRuleQuantityItem extends JRuleNumberItem {
      * @param state state to send.
      */
     default void postUpdateIfDifferent(@NonNull JRuleQuantityValue state) {
-        if(!state.equals(getState())) {
+        if (!state.equals(getState())) {
             postUncheckedUpdate(state);
         }
     }
@@ -171,7 +171,7 @@ public interface JRuleQuantityItem extends JRuleNumberItem {
      * @param command as number via JRuleDecimalValue will be sent.
      */
     default void sendCommandIfDifferent(double command) {
-        if(getStateAsDecimal() != null && Math.abs(getStateAsDecimal().doubleValue() - command) < 0.0001) {
+        if (getStateAsDecimal() != null && Math.abs(getStateAsDecimal().doubleValue() - command) < 0.0001) {
             sendUncheckedCommand(new JRuleDecimalValue(command));
         }
     }
@@ -191,7 +191,7 @@ public interface JRuleQuantityItem extends JRuleNumberItem {
      * @param state as number via JRuleDecimalValue will be sent.
      */
     default void postUpdateIfDifferent(double state) {
-        if(getStateAsDecimal() != null && Math.abs(getStateAsDecimal().doubleValue() - state) < 0.0001) {
+        if (getStateAsDecimal() != null && Math.abs(getStateAsDecimal().doubleValue() - state) < 0.0001) {
             postUncheckedUpdate(new JRuleDecimalValue(state));
         }
     }
@@ -211,7 +211,7 @@ public interface JRuleQuantityItem extends JRuleNumberItem {
      * @param command as number via JRuleDecimalValue will be sent.
      */
     default void sendCommandIfDifferent(int command) {
-        if(getStateAsDecimal() != null && Math.abs(getStateAsDecimal().doubleValue() - command) < 0.0001) {
+        if (getStateAsDecimal() != null && Math.abs(getStateAsDecimal().doubleValue() - command) < 0.0001) {
             sendUncheckedCommand(new JRuleDecimalValue(command));
         }
     }
@@ -231,7 +231,7 @@ public interface JRuleQuantityItem extends JRuleNumberItem {
      * @param state as number via JRuleDecimalValue will be sent.
      */
     default void postUpdateIfDifferent(int state) {
-        if(getStateAsDecimal() != null && Math.abs(getStateAsDecimal().doubleValue() - state) < 0.0001) {
+        if (getStateAsDecimal() != null && Math.abs(getStateAsDecimal().doubleValue() - state) < 0.0001) {
             postUncheckedUpdate(new JRuleDecimalValue(state));
         }
     }

--- a/src/main/java/org/openhab/automation/jrule/items/JRuleStringItem.java
+++ b/src/main/java/org/openhab/automation/jrule/items/JRuleStringItem.java
@@ -74,9 +74,6 @@ public interface JRuleStringItem extends JRuleItem {
         }
     }
 
-
-
-
     /**
      * Sends a string command
      *

--- a/src/main/java/org/openhab/automation/jrule/items/JRuleStringItem.java
+++ b/src/main/java/org/openhab/automation/jrule/items/JRuleStringItem.java
@@ -14,6 +14,7 @@ package org.openhab.automation.jrule.items;
 
 import java.util.Optional;
 
+import org.eclipse.jdt.annotation.NonNull;
 import org.openhab.automation.jrule.exception.JRuleItemNotFoundException;
 import org.openhab.automation.jrule.internal.JRuleUtil;
 import org.openhab.automation.jrule.internal.items.JRuleInternalStringItem;
@@ -38,8 +39,19 @@ public interface JRuleStringItem extends JRuleItem {
      * 
      * @param command command to send.
      */
-    default void sendCommand(JRuleStringValue command) {
+    default void sendCommand(@NonNull JRuleStringValue command) {
         sendUncheckedCommand(command);
+    }
+
+    /**
+     * Sends a string command only if current state is different
+     *
+     * @param command command to send.
+     */
+    default void sendCommandIfDifferent(@NonNull JRuleStringValue command) {
+        if (!command.equals(getState())) {
+            sendUncheckedCommand(command);
+        }
     }
 
     /**
@@ -47,17 +59,40 @@ public interface JRuleStringItem extends JRuleItem {
      * 
      * @param state update to send
      */
-    default void postUpdate(JRuleStringValue state) {
+    default void postUpdate(@NonNull JRuleStringValue state) {
         postUncheckedUpdate(state);
     }
+
+    /**
+     * Sends a string update only if current state is different
+     *
+     * @param state update to send
+     */
+    default void postUpdateIfDifferent(@NonNull JRuleStringValue state) {
+        if (!state.equals(getState())) {
+            postUncheckedUpdate(state);
+        }
+    }
+
+
+
 
     /**
      * Sends a string command
      *
      * @param command string command
      */
-    default void sendCommand(String command) {
+    default void sendCommand(@NonNull String command) {
         sendUncheckedCommand(new JRuleStringValue(command));
+    }
+
+    /**
+     * Sends a string command only if current state is different
+     *
+     * @param command string command
+     */
+    default void sendCommandIfDifferent(@NonNull String command) {
+        sendCommandIfDifferent(new JRuleStringValue(command));
     }
 
     /**
@@ -65,7 +100,16 @@ public interface JRuleStringItem extends JRuleItem {
      *
      * @param state string command
      */
-    default void postUpdate(String state) {
+    default void postUpdate(@NonNull String state) {
         postUncheckedUpdate(new JRuleStringValue(state));
+    }
+
+    /**
+     * Sends a string update only if current state is different
+     *
+     * @param state string command
+     */
+    default void postUpdateIfDifferent(@NonNull String state) {
+        postUpdateIfDifferent(new JRuleStringValue(state));
     }
 }

--- a/src/main/java/org/openhab/automation/jrule/items/JRuleSwitchItem.java
+++ b/src/main/java/org/openhab/automation/jrule/items/JRuleSwitchItem.java
@@ -89,7 +89,7 @@ public interface JRuleSwitchItem extends JRuleItem {
     }
 
     /**
-     * Sends an on/off command
+     * Sends an on/off command only if current state is different
      *
      * @param command command to send.
      */
@@ -108,7 +108,7 @@ public interface JRuleSwitchItem extends JRuleItem {
     }
 
     /**
-     * Sends an on/off update
+     * Sends an on/off update only if current state is different
      *
      * @param state update to send
      */

--- a/src/main/java/org/openhab/automation/jrule/items/JRuleSwitchItem.java
+++ b/src/main/java/org/openhab/automation/jrule/items/JRuleSwitchItem.java
@@ -14,11 +14,13 @@ package org.openhab.automation.jrule.items;
 
 import java.util.Optional;
 
+import org.eclipse.jdt.annotation.NonNull;
 import org.openhab.automation.jrule.exception.JRuleItemNotFoundException;
 import org.openhab.automation.jrule.internal.JRuleUtil;
 import org.openhab.automation.jrule.internal.handler.JRuleEventHandler;
 import org.openhab.automation.jrule.internal.items.JRuleInternalSwitchItem;
 import org.openhab.automation.jrule.rules.value.JRuleOnOffValue;
+import org.openhab.automation.jrule.rules.value.JRuleValue;
 
 /**
  * The {@link JRuleSwitchItem} JRule Item
@@ -38,25 +40,47 @@ public interface JRuleSwitchItem extends JRuleItem {
     }
 
     /**
-     * Sends a on/off command
+     * Sends an on/off command
      * 
      * @param command command to send.
      */
-    default void sendCommand(JRuleOnOffValue command) {
+    default void sendCommand(@NonNull JRuleOnOffValue command) {
         sendUncheckedCommand(command);
     }
 
     /**
-     * Sends a on/off update
+     * Sends an on/off command only if current state is different
+     *
+     * @param command command to send.
+     */
+    default void sendCommandIfDifferent(@NonNull JRuleOnOffValue command) {
+        if (!command.equals(getState())) {
+            sendUncheckedCommand(command);
+        }
+    }
+
+    /**
+     * Sends an on/off update
      * 
      * @param state update to send
      */
-    default void postUpdate(JRuleOnOffValue state) {
+    default void postUpdate(@NonNull JRuleOnOffValue state) {
         postUncheckedUpdate(state);
     }
 
     /**
-     * Sends a on/off command
+     * Sends an on/off update only if current state is different
+     *
+     * @param state update to send
+     */
+    default void postUpdateIfDifferent(@NonNull JRuleOnOffValue state) {
+        if (!state.equals(getState())) {
+            postUncheckedUpdate(state);
+        }
+    }
+
+    /**
+     * Sends an on/off command
      * 
      * @param command command to send.
      */
@@ -65,12 +89,32 @@ public interface JRuleSwitchItem extends JRuleItem {
     }
 
     /**
-     * Sends a on/off update
+     * Sends an on/off command
+     *
+     * @param command command to send.
+     */
+    default void sendCommandIfDifferent(boolean command) {
+        JRuleValue newValue = JRuleOnOffValue.valueOf(command);
+        sendCommandIfDifferent((JRuleOnOffValue) newValue);
+    }
+
+    /**
+     * Sends an on/off update
      * 
      * @param state update to send
      */
     default void postUpdate(boolean state) {
         postUncheckedUpdate(JRuleOnOffValue.valueOf(state));
+    }
+
+    /**
+     * Sends an on/off update
+     *
+     * @param state update to send
+     */
+    default void postUpdateIfDifferent(boolean state) {
+        JRuleValue newValue = JRuleOnOffValue.valueOf(state);
+        postUpdateIfDifferent((JRuleOnOffValue) newValue);
     }
 
     default JRuleOnOffValue getStateAsOnOff() {

--- a/src/test/java/org/openhab/automation/jrule/rules/user/TestRules.java
+++ b/src/test/java/org/openhab/automation/jrule/rules/user/TestRules.java
@@ -335,11 +335,11 @@ public class TestRules extends JRule {
     @JRuleWhenItemReceivedCommand(item = ITEM_TRIGGER_RULE, condition = @JRuleCondition(eq = COMMAND_NULL_TESTING))
     public void nullTesting(JRuleItemEvent event) throws JRuleExecutionException {
         JRuleStringItem stringItem = JRuleStringItem.forName(ITEM_NULL_TESTING);
-        stringItem.postUpdate((JRuleStringValue) null);
+        stringItem.postNullUpdate();
         assert stringItem.getState() == null;
         stringItem.postUpdate("abc");
         assert stringItem.getState().stringValue().equals("abc");
-        stringItem.postUpdate((JRuleStringValue) null);
+        stringItem.postNullUpdate();
         assert stringItem.getState() == null;
     }
 


### PR DESCRIPTION
Add convenience method to only send commands and updates if current state is different from the command/update state.

Rationale: Reduce unnecessary commands/updates in db and logs