### PR TITLE
Compatibility with Openhab 5.0.2

### DIFF
--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -5,10 +5,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Set up JDK 17
+    - name: Set up JDK 21
       uses: actions/setup-java@v3
       with:
-        java-version: '17'
+        java-version: '21'
         distribution: 'adopt'
         cache: 'maven'
     - name: Build with Maven

--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -1,5 +1,5 @@
 name: Java CI
-on: [ push,pull_request,workflow_dispatch ]
+on: [ push,pull_request ]
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -12,7 +12,7 @@ jobs:
         distribution: 'adopt'
         cache: 'maven'
     - name: Build with Maven
-      run: mvn --batch-mode --update-snapshots install
+      run: mvn --batch-mode --update-snapshots install -P="skipXmlValidation"
     - run: mkdir staging && cp target/org.openhab.automation.jrule*SNAPSHOT.jar staging
     - uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -1,5 +1,5 @@
 name: Java CI
-on: [ push,pull_request ]
+on: [ push,pull_request,workflow_dispatch ]
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/doc/EXAMPLES.md
+++ b/doc/EXAMPLES.md
@@ -46,6 +46,7 @@
     + [Example 42 - Persist future data](#example-42---persist-future-data)
     + [Example 43 - Creating a rule dynamically using JRuleBuilder](#example-43---creating-a-rule-dynamically-using-jrulebuilder)
     + [Example 44 - Setting items linked to a thing to UNDEF when thing goes offline](#example-44---setting-items-linked-to-a-thing-to-undef-when-thing-goes-offline)
+    + [Example 45 - Getting the timestamp of the previous state update/change when a state change event occurred](#example-45---getting-the-timestamp-of-the-previous-state-update-change-when-a-state-change-event-occurred)
 
 ### Example 1 - Invoke another item Switch from rule
 
@@ -1043,7 +1044,7 @@ public class DemoRule extends JRule {
 }
 ```
 
-## Example 41 - Get Metadata and Tags
+### Example 41 - Get Metadata and Tags
 
 Use case: Get Tags and Metadata of Items
 
@@ -1068,7 +1069,7 @@ public class DemoRule extends JRule {
 }
 ```
 
-## Example 42 - Persist future data
+### Example 42 - Persist future data
 
 Use case: Persist future data for e.g. Tibber future prices
 
@@ -1097,7 +1098,7 @@ public class DemoRule extends JRule {
 }
 ```
 
-## Example 43 - Creating a rule dynamically using JRuleBuilder
+### Example 43 - Creating a rule dynamically using JRuleBuilder
 
 Use case: Build a rule dynamically during runtime without static annotations. Can be used when rule parameters are not
 known at compile time, e.g. when they are read from a configuration file
@@ -1127,7 +1128,7 @@ public class DynamicRuleModule extends JRule {
 }
 ```
 
-## Example 44 - Setting items linked to a thing to UNDEF when thing goes offline
+### Example 44 - Setting items linked to a thing to UNDEF when thing goes offline
 
 Use case: No longer be fooled by outdated item states when a thing goes offline
 
@@ -1154,6 +1155,64 @@ public class ChannelsToUndefWhenTingOffline extends JRule {
     JRuleAbstractThing thing = JRuleThingRegistry.get(thingUID, JRuleAbstractThing.class);
     List<JRuleChannel> channels = thing.getChannels();
     channels.forEach(channel -> thing.getLinkedItems(channel).forEach(JRuleItem::postUndefUpdate));
+  }
+}
+```
+
+### Example 45 - Getting the timestamp of the previous state update/change when a state change event occurred
+
+Use case: Getting the duration how long an item was in the previous state before changing
+
+```java
+package org.openhab.automation.jrule.rules.user;
+
+import static org.openhab.automation.jrule.generated.items.JRuleItemNames.switchItem;
+import static org.openhab.automation.jrule.rules.value.JRuleOnOffValue.OFF;
+import static org.openhab.automation.jrule.rules.value.JRuleOnOffValue.ON;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+import org.apache.commons.lang3.time.DurationFormatUtils;
+import org.openhab.automation.jrule.rules.JRule;
+import org.openhab.automation.jrule.rules.JRuleName;
+import org.openhab.automation.jrule.rules.JRuleWhenItemChange;
+import org.openhab.automation.jrule.rules.event.JRuleItemEvent;
+import org.openhab.automation.jrule.rules.value.JRuleValue;
+
+public class TimestampsLastUpdateLastChange extends JRule{
+
+  @JRuleName("Getting the duration of previous state")
+  @JRuleWhenItemChange(item=switchItem)
+  public void getDurationOfPreviousState(JRuleItemEvent event) {
+    JRuleValue previousState = event.getOldState();
+    JRuleValue currentState = event.getState();
+    ZonedDateTime lastChange = event.getLastStateChange();
+    ZonedDateTime lastUpdate = event.getLastStateUpdate();
+    String itemName = event.getItem().getName();
+
+    if(lastChange != null) {
+      Duration dur = Duration.between(lastChange, Instant.now().atZone(ZoneId.systemDefault()));
+      String formattedDuration = DurationFormatUtils.formatDurationWords(dur.toMillis(), true, true);
+      logInfo("Item {} was in state {} for {} before changing to {}.", itemName, previousState, formattedDuration, currentState);
+
+      // If switch was ON for longer than 1 minutes, log a warning
+      if(previousState == ON && currentState == OFF && dur.toMinutes() >= 1) {
+        logWarn("Item {} was ON for more than 1 minutes before turning OFF ({}).", itemName, formattedDuration);
+      }
+    }
+    else {
+      logInfo("Item {} was in state {} since unknown time before changing to {}.", itemName, previousState, currentState);
+    }
+
+    if(lastUpdate != null) {
+      logInfo("Item {} was last updated at {}.", itemName, lastUpdate);
+    }
+    else {
+      logInfo("Item {} was never updated.", itemName);
+    }
   }
 }
 ```

--- a/doc/EXAMPLES.md
+++ b/doc/EXAMPLES.md
@@ -1182,10 +1182,10 @@ import org.openhab.automation.jrule.rules.JRuleWhenItemChange;
 import org.openhab.automation.jrule.rules.event.JRuleItemEvent;
 import org.openhab.automation.jrule.rules.value.JRuleValue;
 
-public class TimestampsLastUpdateLastChange extends JRule{
+public class TimestampsLastUpdateLastChange extends JRule {
 
   @JRuleName("Getting the duration of previous state")
-  @JRuleWhenItemChange(item=switchItem)
+  @JRuleWhenItemChange(item = switchItem)
   public void getDurationOfPreviousState(JRuleItemEvent event) {
     JRuleValue previousState = event.getOldState();
     JRuleValue currentState = event.getState();
@@ -1193,21 +1193,21 @@ public class TimestampsLastUpdateLastChange extends JRule{
     ZonedDateTime lastUpdate = event.getLastStateUpdate();
     String itemName = event.getItem().getName();
 
-    if(lastChange != null) {
+    if (lastChange != null) {
       Duration dur = Duration.between(lastChange, Instant.now().atZone(ZoneId.systemDefault()));
       String formattedDuration = DurationFormatUtils.formatDurationWords(dur.toMillis(), true, true);
       logInfo("Item {} was in state {} for {} before changing to {}.", itemName, previousState, formattedDuration, currentState);
 
-      // If switch was ON for longer than 1 minutes, log a warning
-      if(previousState == ON && currentState == OFF && dur.toMinutes() >= 1) {
-        logWarn("Item {} was ON for more than 1 minutes before turning OFF ({}).", itemName, formattedDuration);
+      // If switch was ON for longer than 1 minute, log a warning
+      if (previousState == ON && currentState == OFF && dur.toMinutes() >= 1) {
+        logWarn("Item {} was ON for more than 1 minute before turning OFF ({}).", itemName, formattedDuration);
       }
     }
     else {
       logInfo("Item {} was in state {} since unknown time before changing to {}.", itemName, previousState, currentState);
     }
 
-    if(lastUpdate != null) {
+    if (lastUpdate != null) {
       logInfo("Item {} was last updated at {}.", itemName, lastUpdate);
     }
     else {

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,2 +1,2 @@
 jdk:
-  - openjdk17
+  - openjdk21

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,11 @@
       org.mozilla.javascript.*;resolution:=optional,\
       org.python.*;resolution:=optional,\
       org.zeroturnaround.javarebel.*;resolution:=optional,\
-      org.apache.tools.ant.*;resolution:=optional</bnd.importpackage>
+      org.apache.tools.ant.*;resolution:=optional,\
+      jakarta.el.*;resolution:=optional,\
+      jakarta.servlet.*;resolution:=optional,\
+      javax.el.*;resolution:=optional,\
+      javax.servlet.*;resolution:=optional</bnd.importpackage>
   </properties>
   <dependencies>
     <dependency>
@@ -83,11 +87,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>javax.el</groupId>
-      <artifactId>javax.el-api</artifactId>
-      <version>2.2.4</version>
-    </dependency>
-    <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>jsp-api</artifactId>
       <version>2.0</version>
@@ -122,7 +121,6 @@
       </testResource>
     </testResources>
     <plugins>
-
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -1,19 +1,19 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-v4_0_0.xsd">
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-v4_0_0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.openhab.addons.bundles</groupId>
     <artifactId>org.openhab.addons.reactor.bundles</artifactId>
-    <version>4.2.0</version>
+    <version>5.0.2</version>
   </parent>
   <artifactId>org.openhab.automation.jrule</artifactId>
+  <version>5.0.2-SNAPSHOT</version>
   <name>openHAB Add-ons :: Bundles :: Standalone Java Rules Automation</name>
-  <version>4.2.1-SNAPSHOT</version>
 
   <properties>
-    <testcontainers.version>1.20.4</testcontainers.version>
+    <testcontainers.version>1.21.3</testcontainers.version>
     <bnd.importpackage>com.sun.org.apache.xml.internal.utils.*;resolution:=optional,\
       com.sun.org.apache.xpath.internal.*;resolution:=optional,\
       org.apache.log.*;resolution:=optional,\
@@ -25,48 +25,19 @@
       org.mozilla.javascript.*;resolution:=optional,\
       org.python.*;resolution:=optional,\
       org.zeroturnaround.javarebel.*;resolution:=optional,\
-      org.apache.tools.ant.*;resolution:=optional
-    </bnd.importpackage>
+      org.apache.tools.ant.*;resolution:=optional</bnd.importpackage>
   </properties>
-  <build>
-    <testResources>
-      <testResource>
-        <directory>src/test/resources</directory>
-        <filtering>false</filtering>
-      </testResource>
-      <testResource>
-        <directory>src/test/maven-resources</directory>
-        <filtering>true</filtering>
-      </testResource>
-    </testResources>
-    <plugins>
-
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-failsafe-plugin</artifactId>
-        <version>3.0.0-M7</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>integration-test</goal>
-              <goal>verify</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-  </build>
   <dependencies>
     <dependency>
       <groupId>org.freemarker</groupId>
       <artifactId>freemarker</artifactId>
-      <version>2.3.32</version>
+      <version>2.3.34</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
-      <version>4.2.0</version>
+      <version>4.3.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -96,7 +67,7 @@
     <dependency>
       <groupId>org.wiremock</groupId>
       <artifactId>wiremock</artifactId>
-      <version>3.8.0</version>
+      <version>3.13.1</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -107,8 +78,8 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-inline</artifactId>
-      <version>4.8.1</version>
+      <artifactId>mockito-core</artifactId>
+      <version>5.20.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -125,20 +96,48 @@
 
   <repositories>
     <repository>
-      <id>openhab-release</id>
-      <url>https://openhab.jfrog.io/artifactory/libs-release</url>
       <snapshots>
         <enabled>false</enabled>
       </snapshots>
+      <id>openhab-release</id>
+      <url>https://openhab.jfrog.io/artifactory/libs-release</url>
     </repository>
     <repository>
-      <id>openhab-snapshot</id>
-      <url>https://openhab.jfrog.io/artifactory/libs-snapshot</url>
       <snapshots>
         <enabled>true</enabled>
       </snapshots>
+      <id>openhab-snapshot</id>
+      <url>https://openhab.jfrog.io/artifactory/libs-snapshot</url>
     </repository>
   </repositories>
+  <build>
+    <testResources>
+      <testResource>
+        <filtering>false</filtering>
+        <directory>src/test/resources</directory>
+      </testResource>
+      <testResource>
+        <filtering>true</filtering>
+        <directory>src/test/maven-resources</directory>
+      </testResource>
+    </testResources>
+    <plugins>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <version>3.0.0-M7</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
   <profiles>
     <profile>
       <id>standalone</id>

--- a/src/main/history/dependencies.xml
+++ b/src/main/history/dependencies.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<features xmlns="http://karaf.apache.org/xmlns/features/v1.6.0" name="org.openhab.automation.jrule-4.2.1-SNAPSHOT">
+<features xmlns="http://karaf.apache.org/xmlns/features/v1.6.0" name="org.openhab.automation.jrule-5.0.2-SNAPSHOT">
     <feature version="0.0.0">
         <feature>openhab-runtime-base</feature>
         <feature>wrap</feature>
         <bundle>mvn:javax.el/javax.el-api/2.2.4</bundle>
-        <bundle>mvn:org.freemarker/freemarker/2.3.32</bundle>
-        <bundle>mvn:org.openhab.addons.bundles/org.openhab.automation.jrule/4.2.1-SNAPSHOT</bundle>
+        <bundle>mvn:org.freemarker/freemarker/2.3.34</bundle>
+        <bundle>mvn:org.openhab.addons.bundles/org.openhab.automation.jrule/5.0.2-SNAPSHOT</bundle>
         <bundle>wrap:mvn:javax.servlet/jsp-api/2.0</bundle>
         <bundle>wrap:mvn:javax.servlet/servlet-api/2.4</bundle>
-        <bundle>wrap:mvn:org.lastnpe.eea/eea-all/2.2.1</bundle>
+        <bundle>wrap:mvn:org.lastnpe.eea/eea-all/2.4.0</bundle>
     </feature>
 </features>

--- a/src/main/history/dependencies.xml
+++ b/src/main/history/dependencies.xml
@@ -3,7 +3,6 @@
     <feature version="0.0.0">
         <feature>openhab-runtime-base</feature>
         <feature>wrap</feature>
-        <bundle>mvn:javax.el/javax.el-api/2.2.4</bundle>
         <bundle>mvn:org.freemarker/freemarker/2.3.34</bundle>
         <bundle>mvn:org.openhab.addons.bundles/org.openhab.automation.jrule/5.0.2-SNAPSHOT</bundle>
         <bundle>wrap:mvn:javax.servlet/jsp-api/2.0</bundle>

--- a/src/main/java/org/openhab/automation/jrule/internal/engine/excutioncontext/JRuleItemChangeExecutionContext.java
+++ b/src/main/java/org/openhab/automation/jrule/internal/engine/excutioncontext/JRuleItemChangeExecutionContext.java
@@ -107,7 +107,9 @@ public class JRuleItemChangeExecutionContext extends JRuleItemExecutionContext {
 
         return new JRuleItemEvent(item, memberItem,
                 JRuleEventHandler.get().toValue(((ItemStateChangedEvent) event).getItemState()),
-                JRuleEventHandler.get().toValue(((ItemStateChangedEvent) event).getOldItemState()));
+                JRuleEventHandler.get().toValue(((ItemStateChangedEvent) event).getOldItemState()),
+                ((ItemStateChangedEvent) event).getLastStateUpdate(),
+                ((ItemStateChangedEvent) event).getLastStateChange());
     }
 
     @Override

--- a/src/main/java/org/openhab/automation/jrule/internal/engine/excutioncontext/JRuleItemReceivedCommandExecutionContext.java
+++ b/src/main/java/org/openhab/automation/jrule/internal/engine/excutioncontext/JRuleItemReceivedCommandExecutionContext.java
@@ -88,7 +88,7 @@ public class JRuleItemReceivedCommandExecutionContext extends JRuleItemExecution
         }
 
         return new JRuleItemEvent(item, memberItem,
-                JRuleEventHandler.get().toValue(((ItemCommandEvent) event).getItemCommand()), null);
+                JRuleEventHandler.get().toValue(((ItemCommandEvent) event).getItemCommand()), null, null, null);
     }
 
     @Override

--- a/src/main/java/org/openhab/automation/jrule/internal/engine/excutioncontext/JRuleItemReceivedUpdateExecutionContext.java
+++ b/src/main/java/org/openhab/automation/jrule/internal/engine/excutioncontext/JRuleItemReceivedUpdateExecutionContext.java
@@ -90,7 +90,7 @@ public class JRuleItemReceivedUpdateExecutionContext extends JRuleItemExecutionC
         // ((ItemStateEvent) event).getItemState());
 
         return new JRuleItemEvent(item, memberItem,
-                JRuleEventHandler.get().toValue(((ItemStateEvent) event).getItemState()), null);
+                JRuleEventHandler.get().toValue(((ItemStateEvent) event).getItemState()), null, null, null);
     }
 
     @Override

--- a/src/main/java/org/openhab/automation/jrule/internal/test/JRuleMockedItemStateChangedEvent.java
+++ b/src/main/java/org/openhab/automation/jrule/internal/test/JRuleMockedItemStateChangedEvent.java
@@ -24,7 +24,7 @@ public class JRuleMockedItemStateChangedEvent extends ItemStateChangedEvent {
 
     protected JRuleMockedItemStateChangedEvent(String topic, String payload, String itemName, State newItemState,
             State oldItemState) {
-        super(topic, payload, itemName, newItemState, oldItemState);
+        super(topic, payload, itemName, newItemState, oldItemState, null, null);
     }
 
     @Override

--- a/src/main/java/org/openhab/automation/jrule/rules/event/JRuleItemEvent.java
+++ b/src/main/java/org/openhab/automation/jrule/rules/event/JRuleItemEvent.java
@@ -12,6 +12,9 @@
  */
 package org.openhab.automation.jrule.rules.event;
 
+import java.time.ZonedDateTime;
+
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.automation.jrule.exception.JRuleRuntimeException;
 import org.openhab.automation.jrule.items.JRuleItem;
 import org.openhab.automation.jrule.rules.value.JRuleValue;
@@ -29,11 +32,17 @@ public class JRuleItemEvent extends JRuleEvent {
     private final JRuleValue state;
     private final JRuleValue oldState;
 
-    public JRuleItemEvent(JRuleItem item, JRuleItem memberItem, JRuleValue state, JRuleValue oldState) {
+    private final @Nullable ZonedDateTime lastStateUpdate;
+    private final @Nullable ZonedDateTime lastStateChange;
+
+    public JRuleItemEvent(JRuleItem item, JRuleItem memberItem, JRuleValue state, JRuleValue oldState,
+            @Nullable ZonedDateTime lastStateUpdate, @Nullable ZonedDateTime lastStateChange) {
         this.item = item;
         this.memberItem = memberItem;
         this.state = state;
         this.oldState = oldState;
+        this.lastStateUpdate = lastStateUpdate;
+        this.lastStateChange = lastStateChange;
     }
 
     public JRuleItem getItem() {
@@ -89,6 +98,24 @@ public class JRuleItemEvent extends JRuleEvent {
      */
     public JRuleValue getOldState() {
         return oldState;
+    }
+
+    /**
+     * Gets the timestamp of the previous state update that occurred prior to this event.
+     *
+     * @return the last state update
+     */
+    public @Nullable ZonedDateTime getLastStateUpdate() {
+        return lastStateUpdate;
+    }
+
+    /**
+     * Gets the timestamp of the previous state change that occurred prior to this event.
+     *
+     * @return the last state change
+     */
+    public @Nullable ZonedDateTime getLastStateChange() {
+        return lastStateChange;
     }
 
     @Override

--- a/src/main/java/org/openhab/automation/jrule/rules/event/JRuleItemEvent.java
+++ b/src/main/java/org/openhab/automation/jrule/rules/event/JRuleItemEvent.java
@@ -120,6 +120,7 @@ public class JRuleItemEvent extends JRuleEvent {
 
     @Override
     public String toString() {
-        return String.format("JRuleEvent [item=%s, memberItem=%s, oldState=%s]", item, memberItem, oldState);
+        return String.format("JRuleEvent [item=%s, memberItem=%s, oldState=%s, lastStateUpdate=%s, lastStateChange=%s]",
+                item, memberItem, oldState, lastStateUpdate, lastStateChange);
     }
 }

--- a/src/test/java/org/openhab/automation/jrule/internal/rules/delayed/JRuleDelayedTest.java
+++ b/src/test/java/org/openhab/automation/jrule/internal/rules/delayed/JRuleDelayedTest.java
@@ -78,6 +78,6 @@ public class JRuleDelayedTest extends JRuleAbstractTest {
     }
 
     private Event itemChangeEvent(String item, String from, String to) {
-        return ItemEventFactory.createStateChangedEvent(item, new StringType(to), new StringType(from));
+        return ItemEventFactory.createStateChangedEvent(item, new StringType(to), new StringType(from), null, null);
     }
 }

--- a/src/test/java/org/openhab/automation/jrule/internal/rules/timers/JRuleTimerTest.java
+++ b/src/test/java/org/openhab/automation/jrule/internal/rules/timers/JRuleTimerTest.java
@@ -169,7 +169,7 @@ public class JRuleTimerTest extends JRuleAbstractTest {
     }
 
     private Event itemChangeEvent(String item, String from, String to) {
-        return ItemEventFactory.createStateChangedEvent(item, new StringType(to), new StringType(from));
+        return ItemEventFactory.createStateChangedEvent(item, new StringType(to), new StringType(from), null, null);
     }
 
     private Event itemCommandEvent(String item, String to) {

--- a/src/test/java/org/openhab/automation/jrule/internal/rules/triggers/itemchange/JRuleItemChangeTest.java
+++ b/src/test/java/org/openhab/automation/jrule/internal/rules/triggers/itemchange/JRuleItemChangeTest.java
@@ -102,11 +102,11 @@ public class JRuleItemChangeTest extends JRuleAbstractTest {
 
     // Syntactic sugar
     private Event itemChangeEvent(String item, String from, String to) {
-        return ItemEventFactory.createStateChangedEvent(item, new StringType(to), new StringType(from));
+        return ItemEventFactory.createStateChangedEvent(item, new StringType(to), new StringType(from), null, null);
     }
 
     private Event groupAggregationItemChangeEvent(String item, String from, String to) {
-        return ItemEventFactory.createGroupStateChangedEvent(item, "any_item", new StringType(to),
-                new StringType(from));
+        return ItemEventFactory.createGroupStateChangedEvent(item, "any_item", new StringType(to), new StringType(from),
+                null, null);
     }
 }

--- a/src/test/java/org/openhab/automation/jrule/internal/rules/triggers/itemchangecondition/JRuleItemChangeConditionTest.java
+++ b/src/test/java/org/openhab/automation/jrule/internal/rules/triggers/itemchangecondition/JRuleItemChangeConditionTest.java
@@ -98,10 +98,11 @@ public class JRuleItemChangeConditionTest extends JRuleAbstractTest {
 
     // Syntactic sugar
     private Event itemChangeEvent(String item, String from, String to) {
-        return ItemEventFactory.createStateChangedEvent(item, new StringType(to), new StringType(from));
+        return ItemEventFactory.createStateChangedEvent(item, new StringType(to), new StringType(from), null, null);
     }
 
     private Event itemQuantityChangeEvent(String item, String from, String to) {
-        return ItemEventFactory.createStateChangedEvent(item, new QuantityType<>(to), new QuantityType<>(from));
+        return ItemEventFactory.createStateChangedEvent(item, new QuantityType<>(to), new QuantityType<>(from), null,
+                null);
     }
 }

--- a/src/test/java/org/openhab/automation/jrule/internal/triggers/itemchange/JRuleGroupItemChangeTest.java
+++ b/src/test/java/org/openhab/automation/jrule/internal/triggers/itemchange/JRuleGroupItemChangeTest.java
@@ -318,7 +318,7 @@ public class JRuleGroupItemChangeTest extends JRuleAbstractTest {
 
     // Syntactic sugar
     private Event itemChangeEvent(String item, String from, String to) {
-        return ItemEventFactory.createStateChangedEvent(item, new StringType(to), new StringType(from));
+        return ItemEventFactory.createStateChangedEvent(item, new StringType(to), new StringType(from), null, null);
     }
 
     // Syntactic sugar

--- a/src/test/java/org/openhab/automation/jrule/rules/integration_test/JRuleITBase.java
+++ b/src/test/java/org/openhab/automation/jrule/rules/integration_test/JRuleITBase.java
@@ -109,7 +109,7 @@ public abstract class JRuleITBase {
     public static final int TIMEOUT = 180;
     public static final String LOG_REGEX_START = "^\\d+:\\d+:\\d+.\\d+.*";
     @SuppressWarnings("resource")
-    private static final GenericContainer<?> openhabContainer = new GenericContainer<>("openhab/openhab:4.2.0-debian")
+    private static final GenericContainer<?> openhabContainer = new GenericContainer<>("openhab/openhab:5.0.2-debian")
             .withCopyToContainer(MountableFile.forClasspathResource("docker/conf", 0777), "/openhab/conf")
             .withCopyFileToContainer(MountableFile.forClasspathResource("docker/log4j2.xml", 0777),
                     "/openhab/userdata/etc/log4j2.xml")

--- a/src/test/java/org/openhab/automation/jrule/test_utils/JRuleItemTestUtils.java
+++ b/src/test/java/org/openhab/automation/jrule/test_utils/JRuleItemTestUtils.java
@@ -93,7 +93,6 @@ public class JRuleItemTestUtils {
                 JRuleCallGroupItem.class));
         items.add(
                 Pair.of(createGroupItem(ImageItem.class, new RawType(new byte[0], "jpeg")), JRuleImageGroupItem.class));
-        // items.add(Pair.of(createGroupItem(null, null), JRuleUnspecifiedGroupItem.class));
         return items;
     }
 

--- a/src/test/java/org/openhab/automation/jrule/test_utils/JRuleItemTestUtils.java
+++ b/src/test/java/org/openhab/automation/jrule/test_utils/JRuleItemTestUtils.java
@@ -93,7 +93,7 @@ public class JRuleItemTestUtils {
                 JRuleCallGroupItem.class));
         items.add(
                 Pair.of(createGroupItem(ImageItem.class, new RawType(new byte[0], "jpeg")), JRuleImageGroupItem.class));
-        items.add(Pair.of(createGroupItem(null, null), JRuleUnspecifiedGroupItem.class));
+        // items.add(Pair.of(createGroupItem(null, null), JRuleUnspecifiedGroupItem.class));
         return items;
     }
 


### PR DESCRIPTION
Changes in POM file:
- Updated parent from OH 4.2.0 to OH 5.0.2
- Updated all dependencies
- Added javax and jakarta to "<bnd.importpackage>" to allow loading of JAR file without the need to include these dependencies

Changes in source files:
- Added "lastStateUpdate" and "lastStateChange" to JRuleItemEvent to make it compatible with Openhab's ItemStateChangedEvent
- Updated tests to make them compatible with Openhab's ItemStateChangedEvent

Other changes:
- Added example how to use "lastStateUpdate" and "lastStateChange" of JRuleItemEvent

Open question:
- "lastStateUpdate" was also added to Openhab's ItemStateUpdatedEvent
- The JRule's event subscriber does not subscribe to this event, but only to ItemStateEvent
- Why does Openhab use ItemStateEvent instead of ItemStateUpdatedEvent for state updates that do not change the state of the item? Do we also want to subscribe to ItemStateUpdatedEvent in the JRuleEventSubscriber just to make sure we can handle it if it occures?