### PR TITLE
Fix thing actions for primitive data types

### DIFF
--- a/src/main/java/org/openhab/automation/jrule/actions/JRuleActionClassGenerator.java
+++ b/src/main/java/org/openhab/automation/jrule/actions/JRuleActionClassGenerator.java
@@ -25,7 +25,6 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
 
-import org.apache.commons.lang3.ClassUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.openhab.automation.jrule.internal.JRuleConfig;
@@ -195,8 +194,8 @@ public class JRuleActionClassGenerator extends JRuleAbstractClassGenerator {
                                 Map<Object, Object> arg = new HashMap<>();
                                 Class<?> parameterType = replaceTypeIfNecessary(parameter.getType());
                                 arg.put("type", parameterType.getTypeName());
-                                arg.put("reflectionType", ClassUtils.primitiveToWrapper(parameter.getType())
-                                        .getTypeName().replaceFirst("java.lang.", ""));
+                                arg.put("reflectionType",
+                                        parameter.getType().getTypeName().replaceFirst("java.lang.", ""));
                                 arg.put("name", parameter.getAnnotation(ActionInput.class).name());
                                 args.add(arg);
                             }


### PR DESCRIPTION
I encountered a bug that results in an exception when trying to invoke a ThingAction method that expects a parameter with a primitive data type. 

For example the Enigma2 binding provides actions that require a timeout in seconds (integer). When calling these function using the autogenerated class that extends "JRuleAbstractAction", it results in an exception. This is because the class tries to find a method with parameter type "Integer.class", instead of "int.class". 

In the [JRuleActionClassGenerator.java](https://github.com/seaside1/jrule/compare/main...Bruetti1991:jrule:thing_actions_primitive_types?expand=1#diff-907ea742b399870629afd913ca7df5e911c012ebca96e5c32ab5bd956a549c08) the primitive class was explicitly converted to a non-primitive (wrapper) one using "ClassUtils.primitiveToWrapper()". Without this call, the thing actions in the Enigma2 binding work perfectly.
What was the reason to add "ClassUtils.primitiveToWrapper()"?
Do we have to support both (primitive and its wrapper classes)?