### PR TITLE
Event source tracking for OH 5.1.0

### DIFF
--- a/doc/EXAMPLES.md
+++ b/doc/EXAMPLES.md
@@ -47,6 +47,7 @@
     + [Example 43 - Creating a rule dynamically using JRuleBuilder](#example-43---creating-a-rule-dynamically-using-jrulebuilder)
     + [Example 44 - Setting items linked to a thing to UNDEF when thing goes offline](#example-44---setting-items-linked-to-a-thing-to-undef-when-thing-goes-offline)
     + [Example 45 - Getting the timestamp of the previous state update/change when a state change event occurred](#example-45---getting-the-timestamp-of-the-previous-state-update-change-when-a-state-change-event-occurred)
+    + [Example 46 - Getting the source that triggered the event](#example-46---getting-the-source-that-triggered-the-event)
 
 ### Example 1 - Invoke another item Switch from rule
 
@@ -1214,5 +1215,50 @@ public class TimestampsLastUpdateLastChange extends JRule {
       logInfo("Item {} was never updated.", itemName);
     }
   }
+}
+```
+
+### Example 46 - Getting the source that triggered the event
+
+Use case: Checking if a rule was triggerd by itself or by a POST request
+
+```java
+package org.openhab.automation.jrule.rules.user;
+
+import java.time.Duration;
+import static org.openhab.automation.jrule.generated.items.JRuleItemNames.switchItem;
+
+import org.openhab.automation.jrule.generated.items.JRuleItems;
+import org.openhab.automation.jrule.rules.JRule;
+import org.openhab.automation.jrule.rules.JRuleName;
+import org.openhab.automation.jrule.rules.JRuleWhenItemChange;
+import org.openhab.automation.jrule.rules.event.JRuleItemEvent;
+import org.openhab.automation.jrule.rules.value.JRuleOnOffValue;
+
+public class EventSource extends JRule {
+         
+    @JRuleName("Switch Reset")
+    @JRuleWhenItemChange(item = switchItem)
+    public void switchReset(JRuleItemEvent event) {
+        logInfo("Item '{}' changed to '{}'. Event source: '{}'", event.getItem().getName(), event.getState().toString(), event.getSource());
+
+        if(event.getSource() != null)
+        {
+            String[] eventParts = event.getSource().split("\\$");
+            if(eventParts.length == 2 && eventParts[0].equals("org.openhab.core.io.rest")) {
+                logInfo("REST Api call detected from user: {}", eventParts[1]);
+            }
+
+            if(event.getSource().startsWith("org.openhab.automation.jrule.rules.user.EventSource$lambda$switchReset")) {
+                logWarn("Loop detected. Exiting...");
+                return;
+            }
+        }
+
+        JRuleOnOffValue newValue = event.getState() == JRuleOnOffValue.ON ? JRuleOnOffValue.OFF : JRuleOnOffValue.ON;
+        createTimer(Duration.ofSeconds(5), (Void) -> {
+            JRuleItems.switchItem.postUpdate(newValue);
+        });
+    }
 }
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -6,10 +6,10 @@
   <parent>
     <groupId>org.openhab.addons.bundles</groupId>
     <artifactId>org.openhab.addons.reactor.bundles</artifactId>
-    <version>5.0.2</version>
+    <version>5.1.0</version>
   </parent>
   <artifactId>org.openhab.automation.jrule</artifactId>
-  <version>5.0.2-SNAPSHOT</version>
+  <version>5.1.0-SNAPSHOT</version>
   <name>openHAB Add-ons :: Bundles :: Standalone Java Rules Automation</name>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>5.20.0</version>
+      <version>5.19.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/history/dependencies.xml
+++ b/src/main/history/dependencies.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<features xmlns="http://karaf.apache.org/xmlns/features/v1.6.0" name="org.openhab.automation.jrule-5.0.2-SNAPSHOT">
+<features xmlns="http://karaf.apache.org/xmlns/features/v1.6.0" name="org.openhab.automation.jrule-5.1.0-SNAPSHOT">
     <feature version="0.0.0">
         <feature>openhab-runtime-base</feature>
         <feature>wrap</feature>
         <bundle>mvn:org.freemarker/freemarker/2.3.34</bundle>
-        <bundle>mvn:org.openhab.addons.bundles/org.openhab.automation.jrule/5.0.2-SNAPSHOT</bundle>
+        <bundle>mvn:org.openhab.addons.bundles/org.openhab.automation.jrule/5.1.0-SNAPSHOT</bundle>
         <bundle>wrap:mvn:javax.servlet/jsp-api/2.0</bundle>
         <bundle>wrap:mvn:javax.servlet/servlet-api/2.4</bundle>
         <bundle>wrap:mvn:org.lastnpe.eea/eea-all/2.4.0</bundle>

--- a/src/main/java/org/openhab/automation/jrule/internal/engine/excutioncontext/JRuleItemChangeExecutionContext.java
+++ b/src/main/java/org/openhab/automation/jrule/internal/engine/excutioncontext/JRuleItemChangeExecutionContext.java
@@ -109,7 +109,7 @@ public class JRuleItemChangeExecutionContext extends JRuleItemExecutionContext {
                 JRuleEventHandler.get().toValue(((ItemStateChangedEvent) event).getItemState()),
                 JRuleEventHandler.get().toValue(((ItemStateChangedEvent) event).getOldItemState()),
                 ((ItemStateChangedEvent) event).getLastStateUpdate(),
-                ((ItemStateChangedEvent) event).getLastStateChange());
+                ((ItemStateChangedEvent) event).getLastStateChange(), event.getSource());
     }
 
     @Override

--- a/src/main/java/org/openhab/automation/jrule/internal/engine/excutioncontext/JRuleItemReceivedCommandExecutionContext.java
+++ b/src/main/java/org/openhab/automation/jrule/internal/engine/excutioncontext/JRuleItemReceivedCommandExecutionContext.java
@@ -88,7 +88,8 @@ public class JRuleItemReceivedCommandExecutionContext extends JRuleItemExecution
         }
 
         return new JRuleItemEvent(item, memberItem,
-                JRuleEventHandler.get().toValue(((ItemCommandEvent) event).getItemCommand()), null, null, null);
+                JRuleEventHandler.get().toValue(((ItemCommandEvent) event).getItemCommand()), null, null, null,
+                event.getSource());
     }
 
     @Override

--- a/src/main/java/org/openhab/automation/jrule/internal/engine/excutioncontext/JRuleItemReceivedUpdateExecutionContext.java
+++ b/src/main/java/org/openhab/automation/jrule/internal/engine/excutioncontext/JRuleItemReceivedUpdateExecutionContext.java
@@ -90,7 +90,8 @@ public class JRuleItemReceivedUpdateExecutionContext extends JRuleItemExecutionC
         // ((ItemStateEvent) event).getItemState());
 
         return new JRuleItemEvent(item, memberItem,
-                JRuleEventHandler.get().toValue(((ItemStateEvent) event).getItemState()), null, null, null);
+                JRuleEventHandler.get().toValue(((ItemStateEvent) event).getItemState()), null, null, null,
+                event.getSource());
     }
 
     @Override

--- a/src/main/java/org/openhab/automation/jrule/internal/handler/JRuleEventHandler.java
+++ b/src/main/java/org/openhab/automation/jrule/internal/handler/JRuleEventHandler.java
@@ -12,6 +12,7 @@
  */
 package org.openhab.automation.jrule.internal.handler;
 
+import java.lang.StackWalker.StackFrame;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -32,6 +33,7 @@ import org.openhab.core.items.events.ItemEventFactory;
 import org.openhab.core.library.types.*;
 import org.openhab.core.types.Command;
 import org.openhab.core.types.State;
+import org.openhab.core.types.Type;
 import org.openhab.core.types.UnDefType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -119,6 +121,28 @@ public class JRuleEventHandler {
         sendCommand(itemName, type);
     }
 
+    private String getSourceRule(String itemName, Type commandOrState) {
+        // Find calling class that extends "JRule" and use this class as source for command/update
+        String source = null;
+
+        try {
+            java.util.Optional<StackFrame> ruleFrameOpt = StackWalker
+                    .getInstance(StackWalker.Option.RETAIN_CLASS_REFERENCE).walk(frames -> frames.filter(f -> {
+                        Class<?> c = f.getDeclaringClass();
+                        return JRule.class.isAssignableFrom(c) && !c.equals(JRule.class);
+                    }).findFirst());
+            StackFrame ruleFrame = ruleFrameOpt.orElse(null);
+            if (ruleFrame != null) {
+                Class<?> ruleClass = ruleFrame.getDeclaringClass();
+                source = ruleClass.getName() + "$" + ruleFrame.getMethodName();
+            }
+        } catch (Throwable t) {
+            throw new JRuleRuntimeException(String.format(
+                    "Failed to resolve caller for item '%s' and command/state '%s'", itemName, commandOrState), t);
+        }
+        return source;
+    }
+
     public void sendCommand(String itemName, Command command) {
         if (eventPublisher == null) {
             return;
@@ -132,7 +156,13 @@ public class JRuleEventHandler {
         } catch (ItemNotFoundException e) {
             throw new JRuleRuntimeException("cannot resolve item: " + itemName, e);
         }
-        eventPublisher.post(ItemEventFactory.createCommandEvent(itemName, command));
+
+        String source = getSourceRule(itemName, command);
+        if (source == null) {
+            logDebug("Failed to resolve source for command '{}' (item: '{}')", command, itemName);
+        }
+
+        eventPublisher.post(ItemEventFactory.createCommandEvent(itemName, command, source));
     }
 
     public void postUpdate(String itemName, JRuleValue value) {
@@ -169,7 +199,13 @@ public class JRuleEventHandler {
         } catch (ItemNotFoundException e) {
             throw new JRuleRuntimeException("cannot resolve item: " + itemName, e);
         }
-        final ItemEvent itemEvent = ItemEventFactory.createStateEvent(itemName, state);
+
+        String source = getSourceRule(itemName, state);
+        if (source == null) {
+            logDebug("Failed to resolve source for state update '{}' (item: '{}')", state, itemName);
+        }
+
+        final ItemEvent itemEvent = ItemEventFactory.createStateEvent(itemName, state, source);
         eventPublisher.post(itemEvent);
     }
 

--- a/src/main/java/org/openhab/automation/jrule/internal/test/JRuleMockedItemStateChangedEvent.java
+++ b/src/main/java/org/openhab/automation/jrule/internal/test/JRuleMockedItemStateChangedEvent.java
@@ -24,7 +24,7 @@ public class JRuleMockedItemStateChangedEvent extends ItemStateChangedEvent {
 
     protected JRuleMockedItemStateChangedEvent(String topic, String payload, String itemName, State newItemState,
             State oldItemState) {
-        super(topic, payload, itemName, newItemState, oldItemState, null, null);
+        super(topic, payload, itemName, newItemState, oldItemState, null, null, "jrule");
     }
 
     @Override

--- a/src/main/java/org/openhab/automation/jrule/rules/event/JRuleItemEvent.java
+++ b/src/main/java/org/openhab/automation/jrule/rules/event/JRuleItemEvent.java
@@ -35,14 +35,17 @@ public class JRuleItemEvent extends JRuleEvent {
     private final @Nullable ZonedDateTime lastStateUpdate;
     private final @Nullable ZonedDateTime lastStateChange;
 
+    private final @Nullable String source;
+
     public JRuleItemEvent(JRuleItem item, JRuleItem memberItem, JRuleValue state, JRuleValue oldState,
-            @Nullable ZonedDateTime lastStateUpdate, @Nullable ZonedDateTime lastStateChange) {
+            @Nullable ZonedDateTime lastStateUpdate, @Nullable ZonedDateTime lastStateChange, @Nullable String source) {
         this.item = item;
         this.memberItem = memberItem;
         this.state = state;
         this.oldState = oldState;
         this.lastStateUpdate = lastStateUpdate;
         this.lastStateChange = lastStateChange;
+        this.source = source;
     }
 
     public JRuleItem getItem() {
@@ -118,9 +121,19 @@ public class JRuleItemEvent extends JRuleEvent {
         return lastStateChange;
     }
 
+    /**
+     * Gets the source of the event
+     * 
+     * @return the source of the event
+     */
+    public @Nullable String getSource() {
+        return source;
+    }
+
     @Override
     public String toString() {
-        return String.format("JRuleEvent [item=%s, memberItem=%s, oldState=%s, lastStateUpdate=%s, lastStateChange=%s]",
-                item, memberItem, oldState, lastStateUpdate, lastStateChange);
+        return String.format(
+                "JRuleEvent [item=%s, memberItem=%s, oldState=%s, lastStateUpdate=%s, lastStateChange=%s, source=%s]",
+                item, memberItem, oldState, lastStateUpdate, lastStateChange, source);
     }
 }

--- a/src/test/java/org/openhab/automation/jrule/rules/integration_test/ITJRule.java
+++ b/src/test/java/org/openhab/automation/jrule/rules/integration_test/ITJRule.java
@@ -306,4 +306,23 @@ public class ITJRule extends JRuleITBase {
         verifyLogEntry("rule trigger for change: OFF");
         verifyNoError();
     }
+
+    @Test
+    public void switchItemReceiveCommandSource() throws IOException {
+        sendCommand(TestRules.ITEM_COMMAND_SOURCE_POST, "1");
+        verifyRuleWasExecuted(TestRules.EVENT_COMMAND_SOURCE_POST);
+        verifyRuleWasExecuted(TestRules.EVENT_COMMAND_SOURCE_INTERMEDIATE);
+        verifyRuleWasExecuted(TestRules.EVENT_COMMAND_SOURCE_FINAL);
+        verifyRuleWasExecuted(TestRules.EVENT_UPDATE_SOURCE);
+        verifyRuleWasExecuted(TestRules.EVENT_CHANGED_SOURCE);
+        verifyLogEntry("First rule received command. Source: org.openhab.core.io.rest");
+        verifyLogEntry(
+                "Intermediate rule received command. Source: org.openhab.automation.jrule.rules.user.TestRules$itemReceivedCommandSourcePost");
+        verifyLogEntry(
+                "Final rule received command. Source: org.openhab.automation.jrule.rules.user.TestRules$itemReceivedCommandSourceIntermediate");
+        verifyLogEntry(
+                "Rule received update. Source: org.openhab.automation.jrule.rules.user.TestRules$itemReceivedCommandSourceFinal");
+        verifyLogEntry(
+                "Item changed. Source: org.openhab.automation.jrule.rules.user.TestRules$itemReceivedCommandSourceFinal");
+    }
 }

--- a/src/test/java/org/openhab/automation/jrule/rules/integration_test/JRuleITBase.java
+++ b/src/test/java/org/openhab/automation/jrule/rules/integration_test/JRuleITBase.java
@@ -109,7 +109,7 @@ public abstract class JRuleITBase {
     public static final int TIMEOUT = 180;
     public static final String LOG_REGEX_START = "^\\d+:\\d+:\\d+.\\d+.*";
     @SuppressWarnings("resource")
-    private static final GenericContainer<?> openhabContainer = new GenericContainer<>("openhab/openhab:5.0.2-debian")
+    private static final GenericContainer<?> openhabContainer = new GenericContainer<>("openhab/openhab:5.1.0-debian")
             .withCopyToContainer(MountableFile.forClasspathResource("docker/conf", 0777), "/openhab/conf")
             .withCopyFileToContainer(MountableFile.forClasspathResource("docker/log4j2.xml", 0777),
                     "/openhab/userdata/etc/log4j2.xml")

--- a/src/test/java/org/openhab/automation/jrule/rules/user/TestRules.java
+++ b/src/test/java/org/openhab/automation/jrule/rules/user/TestRules.java
@@ -120,6 +120,15 @@ public class TestRules extends JRule {
     public static final String NAME_TRIGGER_ON_GROUP_STATE_CHANGE = "trigger on group state change";
     public static final String ITEM_SWITCH_GROUP_OR = "SwitchGroupOr";
     public static final String TAG_CUSTOM = "custom";
+    public static final String EVENT_COMMAND_SOURCE_POST = "Item received command from POST";
+    public static final String EVENT_COMMAND_SOURCE_INTERMEDIATE = "Item received command from first rule";
+    public static final String EVENT_COMMAND_SOURCE_FINAL = "Item received command from second rule";
+    public static final String EVENT_UPDATE_SOURCE = "Item received update from rule";
+    public static final String EVENT_CHANGED_SOURCE = "Item changed from rule";
+    public static final String ITEM_COMMAND_SOURCE_POST = "Number_Item_Command_Source_From_Post";
+    public static final String ITEM_COMMAND_SOURCE_INTERMEDIATE = "Number_Item_Command_Source_From_Rule_Intermediate";
+    public static final String ITEM_COMMAND_SOURCE_FINAL = "Number_Item_Command_Source_From_Rule_Final";
+    public static final String ITEM_UPDATE_SOURCE = "Number_Item_Update_Source_From_Rule";
 
     @JRuleTag({ TAG_CUSTOM })
     @JRuleName(NAME_SWITCH_ITEM_RECEIVED_ANY_COMMAND)
@@ -415,6 +424,39 @@ public class TestRules extends JRule {
         logInfo("Metadata: '{}'", item.getMetadata());
         logInfo("Metadata Value: '{}'", item.getMetadata().get("VoiceSystem").getValue());
         logInfo("Metadata Configuration: '{}'", item.getMetadata().get("VoiceSystem").getConfiguration());
+    }
+
+    @JRuleName(EVENT_COMMAND_SOURCE_POST)
+    @JRuleWhenItemReceivedCommand(item = ITEM_COMMAND_SOURCE_POST)
+    public void itemReceivedCommandSourcePost(JRuleItemEvent event) {
+        logInfo("First rule received command. Source: {}", event.getSource());
+        JRuleNumberItem.forName(ITEM_COMMAND_SOURCE_INTERMEDIATE).sendCommand((JRuleDecimalValue) event.getState());
+    }
+
+    @JRuleName(EVENT_COMMAND_SOURCE_INTERMEDIATE)
+    @JRuleWhenItemReceivedCommand(item = ITEM_COMMAND_SOURCE_INTERMEDIATE)
+    public void itemReceivedCommandSourceIntermediate(JRuleItemEvent event) {
+        logInfo("Intermediate rule received command. Source: {}", event.getSource());
+        JRuleNumberItem.forName(ITEM_COMMAND_SOURCE_FINAL).sendCommand((JRuleDecimalValue) event.getState());
+    }
+
+    @JRuleName(EVENT_COMMAND_SOURCE_FINAL)
+    @JRuleWhenItemReceivedCommand(item = ITEM_COMMAND_SOURCE_FINAL)
+    public void itemReceivedCommandSourceFinal(JRuleItemEvent event) {
+        logInfo("Final rule received command. Source: {}", event.getSource());
+        JRuleNumberItem.forName(ITEM_UPDATE_SOURCE).postUpdate((JRuleDecimalValue) event.getState());
+    }
+
+    @JRuleName(EVENT_UPDATE_SOURCE)
+    @JRuleWhenItemReceivedUpdate(item = ITEM_UPDATE_SOURCE)
+    public void itemReceivedUpdateSource(JRuleItemEvent event) {
+        logInfo("Rule received update. Source: {}", event.getSource());
+    }
+
+    @JRuleName(EVENT_CHANGED_SOURCE)
+    @JRuleWhenItemChange(item = ITEM_UPDATE_SOURCE)
+    public void itemChangedSourceFinal(JRuleItemEvent event) {
+        logInfo("Item changed. Source: {}", event.getSource());
     }
 
     private static void castLocation() {

--- a/src/test/resources/docker/conf/items/default.items
+++ b/src/test/resources/docker/conf/items/default.items
@@ -89,3 +89,8 @@ Number          Number_To_Persist_Future   (InfluxDbPersist)
 Dimmer          Dimmer_With_Tags_And_Metadata   ["Control", "Light"]	{ Speech="SetLightState" [ location="Livingroom" ] }
 
 Number ItemToUndef {channel="mqtt:topic:mqtt:fromonlinetest:number"}
+
+Number         Number_Item_Command_Source_From_Post
+Number         Number_Item_Command_Source_From_Rule_Intermediate
+Number         Number_Item_Command_Source_From_Rule_Final
+Number         Number_Item_Update_Source_From_Rule


### PR DESCRIPTION
Resolves #227 

- Added compatibility for OH 5.1.0
- Added source member to JRuleItemEvent class
- Fill source with "\<package name\>.\<class name\>$\<methodname\>" when postUpdate or sendCommand is called
  - This is done by walking through the stacktrace and looking for a class that extends "JRule", e.g. "org.openhab.automation.jrule.rules.user.MyRules$customRule"

With help of the event source the user can distinguish where the event came from. E.g.
- API: "org.openhab.core.io.rest"
- Update of an item due to "autoupdate" because of an command: "org.openhab.core.autoupdate"
- JRule rule: org.openhab.automation.jrule.rules.user.*
- lambda function: "org.openhab.automation.jrule.rules.user.MyRules$lambda$customRule$0"